### PR TITLE
fix(rematch): gate next_round on fresh round_state load (#7)

### DIFF
--- a/app/room/[code]/playing.tsx
+++ b/app/room/[code]/playing.tsx
@@ -12,6 +12,7 @@ import {
   guessResultSeenStorageKey,
 } from "@/components/guess-result"
 import { nextRoundAction } from "@/app/actions/next-round"
+import { shouldTriggerNextRound } from "@/lib/round-trigger"
 
 interface InactiveBranchProps {
   myRow: RoundState
@@ -78,6 +79,14 @@ export function Playing() {
 
   const roomId = room?.id ?? null
   const triggeredRoundRef = useRef<number | null>(null)
+  // Gate the next-round trigger on a fresh refetch within THIS mount. Without
+  // this, the host's first render in game 2 inherits stale round_state from
+  // game 1 (still in the Zustand store because no subscription was active
+  // during ENDED/LOBBY), which makes round 1 of game 2 look "already over"
+  // and burns triggeredRoundRef on a no-op next_round call. The legitimate
+  // round-1-end trigger is then suppressed by the ref guard, stalling game 2
+  // on the round-1 scoreboard. (issue #7)
+  const [roundStateLoaded, setRoundStateLoaded] = useState(false)
 
   useEffect(() => {
     if (!roomId) return
@@ -92,6 +101,7 @@ export function Playing() {
         .eq("room_id", roomId!)
       if (!active) return
       setRoundState((refreshed ?? []) as RoundState[])
+      setRoundStateLoaded(true)
     }
 
     async function load() {
@@ -148,11 +158,20 @@ export function Playing() {
 
   useEffect(() => {
     if (!room || !me) return
-    if (!roundOver || !isHost) return
-    if (triggeredRoundRef.current === currentRound) return
+    if (
+      !shouldTriggerNextRound({
+        roundStateLoaded,
+        roundOver,
+        isHost,
+        triggeredRound: triggeredRoundRef.current,
+        currentRound,
+      })
+    ) {
+      return
+    }
     triggeredRoundRef.current = currentRound
     void nextRoundAction({ roomId: room.id, hostPlayerId: me.player_id })
-  }, [room, me, roundOver, isHost, currentRound])
+  }, [room, me, roundStateLoaded, roundOver, isHost, currentRound])
 
   if (!room || !me) {
     return (

--- a/e2e/rematch.spec.ts
+++ b/e2e/rematch.spec.ts
@@ -1,0 +1,185 @@
+import { test, expect, type Page } from "@playwright/test"
+import {
+  createRoom,
+  joinRoom,
+  setRoundsViaUI,
+  startGameAsHost,
+  submitGuessFromCard,
+} from "./_helpers/flow"
+import {
+  getAssignedNameForDisplayName,
+} from "./_helpers/admin"
+
+// Regression coverage for issue #7: rematch must (1) preserve previous-game
+// lobby settings (rounds / top-N / category) and (2) advance round 1 → round 2
+// in game 2 the same way it does in game 1.
+
+async function waitForRound(page: Page, round: number, max: number) {
+  await expect(page.getByText(`Round ${round}/${max}`).first()).toBeVisible({
+    timeout: 20_000,
+  })
+}
+
+async function playRound(
+  hostPage: Page,
+  guestPage: Page,
+  code: string,
+  round: number,
+  maxRounds: number,
+) {
+  await waitForRound(hostPage, round, maxRounds)
+  await waitForRound(guestPage, round, maxRounds)
+
+  const hostName = await getAssignedNameForDisplayName(code, "Host", round)
+  const guestName = await getAssignedNameForDisplayName(code, "Guest", round)
+
+  await submitGuessFromCard(hostPage, hostName)
+  // Skip the 8s GuessResult auto-advance for the host so the spec doesn't idle.
+  const correctResult = hostPage.getByRole("status", { name: "ทายถูก" })
+  await expect(correctResult).toBeVisible({ timeout: 10_000 })
+  await hostPage.getByLabel("ข้ามไปสกอร์บอร์ด").click()
+  await expect(hostPage.getByText(/รอผู้เล่นคนอื่น/)).toBeVisible({
+    timeout: 10_000,
+  })
+
+  await submitGuessFromCard(guestPage, guestName)
+}
+
+test("rematch preserves lobby settings and advances rounds in game 2", async ({
+  browser,
+}) => {
+  const hostCtx = await browser.newContext()
+  const hostPage = await hostCtx.newPage()
+  const guestCtx = await browser.newContext()
+  const guestPage = await guestCtx.newPage()
+
+  try {
+    const code = await createRoom(hostPage, "Host")
+    await joinRoom(guestPage, code, "Guest")
+
+    await expect(hostPage.locator("li", { hasText: "Guest" })).toBeVisible({
+      timeout: 15_000,
+    })
+
+    // Game 1: shorten to 2 rounds. Top-N stays at default (clamped to 1 for 2-player).
+    await setRoundsViaUI(hostPage, 2)
+    await expect(guestPage.locator("#lobby-rounds")).toHaveValue("2", {
+      timeout: 10_000,
+    })
+
+    await startGameAsHost(hostPage)
+
+    // Play game 1 to completion.
+    await playRound(hostPage, guestPage, code, 1, 2)
+    await playRound(hostPage, guestPage, code, 2, 2)
+
+    // Wait for the results screen.
+    await expect(hostPage.getByText("Final Score")).toBeVisible({ timeout: 20_000 })
+    await expect(guestPage.getByText("Final Score")).toBeVisible({ timeout: 20_000 })
+
+    // Bug #1: Click rematch and verify settings persist in the lobby.
+    await hostPage.getByRole("button", { name: /เล่นรอบใหม่/ }).click()
+
+    // Both clients return to the lobby.
+    await expect(hostPage.locator("#lobby-rounds")).toBeVisible({
+      timeout: 15_000,
+    })
+    await expect(guestPage.locator("#lobby-rounds")).toBeVisible({
+      timeout: 15_000,
+    })
+
+    // Settings (rounds = 2 from game 1) must persist on rematch.
+    await expect(hostPage.locator("#lobby-rounds")).toHaveValue("2")
+    await expect(guestPage.locator("#lobby-rounds")).toHaveValue("2")
+
+    // Category select reflects the locked-after-game-1 value.
+    await expect(hostPage.locator("#lobby-category")).toHaveValue(
+      "premier-league",
+    )
+    // Once any round has been played, category select is disabled (locked).
+    await expect(hostPage.locator("#lobby-category")).toBeDisabled()
+
+    // Bug #2: Start game 2 and verify round 1 → round 2 advance.
+    await startGameAsHost(hostPage)
+
+    // Game 2 round 1.
+    await playRound(hostPage, guestPage, code, 1, 2)
+
+    // Game 2 round 2 — this is the bug. If broken, both clients hang on the
+    // game-2 scoreboard and never see the round-2 NameCard.
+    await waitForRound(hostPage, 2, 2)
+    await waitForRound(guestPage, 2, 2)
+
+    // Sanity: finish game 2 too.
+    const hostName = await getAssignedNameForDisplayName(code, "Host", 2)
+    const guestName = await getAssignedNameForDisplayName(code, "Guest", 2)
+    await submitGuessFromCard(hostPage, hostName)
+    await hostPage.getByLabel("ข้ามไปสกอร์บอร์ด").click()
+    await submitGuessFromCard(guestPage, guestName)
+
+    await expect(hostPage.getByText("Final Score")).toBeVisible({
+      timeout: 20_000,
+    })
+  } finally {
+    await hostCtx.close()
+    await guestCtx.close()
+  }
+})
+
+// Error state per rubric: a game where the final round ended on a foul (every
+// player's is_active flipped via wrong guesses) must still let the host
+// rematch with settings intact and round-advance working in game 2.
+test("rematch after foul-ended round persists settings and advances rounds", async ({
+  browser,
+}) => {
+  const hostCtx = await browser.newContext()
+  const hostPage = await hostCtx.newPage()
+  const guestCtx = await browser.newContext()
+  const guestPage = await guestCtx.newPage()
+
+  try {
+    const code = await createRoom(hostPage, "Host")
+    await joinRoom(guestPage, code, "Guest")
+
+    await expect(hostPage.locator("li", { hasText: "Guest" })).toBeVisible({
+      timeout: 15_000,
+    })
+
+    // Game 1: 1 round so we can foul-end it cleanly.
+    await setRoundsViaUI(hostPage, 1)
+    await expect(guestPage.locator("#lobby-rounds")).toHaveValue("1", {
+      timeout: 10_000,
+    })
+
+    await startGameAsHost(hostPage)
+
+    await waitForRound(hostPage, 1, 1)
+    await waitForRound(guestPage, 1, 1)
+
+    // Both players foul (zzz... is not a real player name, so submit_guess
+    // fails the equality + fuzzy checks → FOUL → is_active=false).
+    await submitGuessFromCard(hostPage, "zzznot-a-real-player")
+    await submitGuessFromCard(guestPage, "zzznot-a-real-player")
+
+    // Game ends after the foul-only round.
+    await expect(hostPage.getByText("Final Score")).toBeVisible({
+      timeout: 20_000,
+    })
+
+    // Rematch.
+    await hostPage.getByRole("button", { name: /เล่นรอบใหม่/ }).click()
+    await expect(hostPage.locator("#lobby-rounds")).toHaveValue("1", {
+      timeout: 15_000,
+    })
+    await expect(hostPage.locator("#lobby-category")).toBeDisabled()
+
+    // Game 2 starts and round 1 reaches NameCard for both players (Bug #2
+    // would have stalled this on the post-rematch refetch race).
+    await startGameAsHost(hostPage)
+    await waitForRound(hostPage, 1, 1)
+    await waitForRound(guestPage, 1, 1)
+  } finally {
+    await hostCtx.close()
+    await guestCtx.close()
+  }
+})

--- a/lib/__tests__/round-trigger.test.ts
+++ b/lib/__tests__/round-trigger.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest"
+import {
+  shouldTriggerNextRound,
+  type ShouldTriggerNextRoundInput,
+} from "@/lib/round-trigger"
+
+const baseline: ShouldTriggerNextRoundInput = {
+  roundStateLoaded: true,
+  roundOver: true,
+  isHost: true,
+  triggeredRound: null,
+  currentRound: 1,
+}
+
+describe("shouldTriggerNextRound", () => {
+  test("fires when host sees a freshly loaded round end for the first time", () => {
+    expect(shouldTriggerNextRound(baseline)).toBe(true)
+  })
+
+  test("rematch regression: blocks the trigger while round_state has not been refetched in this mount", () => {
+    // Game 2 round-1 stall (#7): on Playing remount the Zustand store still
+    // has stale rows from game 1, so roundOver looks true. The loaded gate
+    // must hold the trigger off until refetch lands.
+    expect(
+      shouldTriggerNextRound({ ...baseline, roundStateLoaded: false }),
+    ).toBe(false)
+  })
+
+  test("does not fire while the round still has active players", () => {
+    expect(shouldTriggerNextRound({ ...baseline, roundOver: false })).toBe(
+      false,
+    )
+  })
+
+  test("non-host clients never trigger next_round", () => {
+    expect(shouldTriggerNextRound({ ...baseline, isHost: false })).toBe(false)
+  })
+
+  test("idempotent: same round only fires once even if effect re-runs", () => {
+    expect(
+      shouldTriggerNextRound({ ...baseline, triggeredRound: 1 }),
+    ).toBe(false)
+  })
+
+  test("re-fires once currentRound advances past the previously triggered round", () => {
+    expect(
+      shouldTriggerNextRound({
+        ...baseline,
+        triggeredRound: 1,
+        currentRound: 2,
+      }),
+    ).toBe(true)
+  })
+})

--- a/lib/round-trigger.ts
+++ b/lib/round-trigger.ts
@@ -1,0 +1,32 @@
+// Pure guard for the host-only "round is over → call next_round" trigger in
+// `app/room/[code]/playing.tsx`. Lives in its own file so the rules are
+// unit-testable without React render machinery.
+//
+// `roundStateLoaded` is the critical bit: it must remain false until a fresh
+// refetch lands in THIS Playing mount. Without that gate the host's first
+// render after a rematch can inherit stale round_state from the prior game,
+// see roundOver=true on a round nobody played yet, and burn the
+// triggeredRound ref on a no-op next_round call. The real round-1-end trigger
+// is then suppressed because triggeredRound already equals currentRound.
+
+export interface ShouldTriggerNextRoundInput {
+  roundStateLoaded: boolean
+  roundOver: boolean
+  isHost: boolean
+  triggeredRound: number | null
+  currentRound: number
+}
+
+export function shouldTriggerNextRound({
+  roundStateLoaded,
+  roundOver,
+  isHost,
+  triggeredRound,
+  currentRound,
+}: ShouldTriggerNextRoundInput): boolean {
+  if (!roundStateLoaded) return false
+  if (!roundOver) return false
+  if (!isHost) return false
+  if (triggeredRound === currentRound) return false
+  return true
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig, devices } from "@playwright/test"
 
+// Port override lets parallel pm-dev worktrees run their own dev server.
+const PORT = process.env.PORT ?? "3000"
+const BASE_URL = `http://localhost:${PORT}`
+
 export default defineConfig({
   testDir: "./e2e",
   timeout: 60_000,
@@ -9,7 +13,7 @@ export default defineConfig({
   retries: 0,
   reporter: process.env.CI ? "github" : "list",
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL: BASE_URL,
     trace: "retain-on-failure",
     headless: true,
     viewport: { width: 414, height: 896 },
@@ -21,8 +25,8 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "bun run dev",
-    url: "http://localhost:3000",
+    command: `PORT=${PORT} bun run dev`,
+    url: BASE_URL,
     reuseExistingServer: true,
     timeout: 180_000,
     stdout: "ignore",


### PR DESCRIPTION
## Summary

Fixes the game-2 round-1 stall on rematch (#7 Bug #2). The host's `Playing` mount in game 2 inherited stale `round_state` from game 1 in the Zustand store, made round 1 of game 2 look "already over" on the first render, and burned `triggeredRoundRef` on a no-op `next_round` call. The legitimate end-of-round-1 trigger was then suppressed by the ref guard. Fix: gate the trigger on a fresh refetch within THIS Playing mount.

Bug #1 (settings revert) does not reproduce — verified via the new E2E test, which asserts lobby settings persist post-rematch and passes against `main`. `reset_game` preserves `max_rounds`/`score_positions`/`category` in the DB, and `LobbySettings` already re-syncs correctly via the realtime push. Kept the assertion as a permanent regression guard.

Fixes #7

## Changes

- `app/room/[code]/playing.tsx` — add `roundStateLoaded` state and gate the host-only `next_round` trigger on it; trigger logic extracted to `lib/round-trigger.ts` for unit-testability.
- `lib/round-trigger.ts` — pure `shouldTriggerNextRound` guard.
- `lib/__tests__/round-trigger.test.ts` — 6 unit tests covering the rematch regression, host-only, idempotency, and re-fire on round advance.
- `e2e/rematch.spec.ts` — 2 E2E specs: rematch-then-game-2 happy path, and foul-ended rematch (rubric error state).
- `playwright.config.ts` — accept `PORT` env override so parallel pm-dev worktrees can each run their own dev server (otherwise tests target whatever's on :3000, which may be a different branch's code).

## Root cause analysis

### Bug #2: game 2 stalls on scoreboard after round 1

`app/room/[code]/playing.tsx` mounts when `room.status` flips to `PLAYING` and unmounts on every other status. While `Playing` is unmounted (during ENDED → results → LOBBY → start_game), nothing is subscribed to `round_state`, so `reset_game`'s `DELETE` events don't propagate to the Zustand store. The store keeps the full game-1 history.

When `Playing` remounts at the start of game 2:
1. First render reads stale `round_state` (game-1 round-1 rows, all `is_active=false`).
2. `currentRows = roundState.filter(r => r.round_number === currentRound)` returns those stale rows because game-2 round-1 also has `round_number=1`.
3. `roundOver = currentRows.length > 0 && activeRemaining === 0` is `true`.
4. The host-only trigger effect fires, sees `triggeredRoundRef.current === null !== currentRound (1)`, and immediately sets `ref=1` and calls `next_round`.
5. `next_round` raises P0008 (`round still in progress` — the fresh game-2 round-1 rows ARE active in the DB), but the action's error is swallowed.
6. Round 1 of game 2 plays out normally. When it actually ends, the trigger effect re-runs but bails because `triggeredRoundRef.current === 1 === currentRound`. **Stall.**

Fix: `roundStateLoaded` defaults to `false` on every mount and is only set to `true` after the first refetch resolves. The trigger guard refuses to fire while `roundStateLoaded === false`. By the time it flips true, `roundState` has been replaced with fresh game-2 data and `roundOver` is false, so no spurious call lands.

### Bug #1: settings revert to defaults on rematch (not reproduced)

`reset_game` (`supabase/migrations/0006_reset_game.sql`) only resets `status`, `current_round`, `players.total_score`, and the per-round tables — `max_rounds`, `score_positions`, `category`, `category_locked` are explicitly left alone. The realtime UPDATE event publishes the full new row, so `setRoom(payload.new)` carries those fields through, and `LobbySettings`'s state-mirror picks them up on remount via `useState(maxRounds)`. The new E2E spec asserts this behavior end-to-end.

If the user can supply a fresh repro (specific player count, sequence, or older client cache), happy to follow up — but the current codebase already meets AC1.

## Rubric verification
- [x] After clicking "เล่นรอบใหม่", the lobby shows the previous game's rounds, top-N, and category — verified: e2e/rematch.spec.ts:48 asserts `#lobby-rounds` value matches the pre-rematch value, `#lobby-category` shows `premier-league` and is disabled (categoryLocked=true). NOTE: Bug #1 did NOT reproduce — settings already persist correctly because reset_game leaves max_rounds/score_positions/category untouched in the DB and LobbySettings re-syncs from the realtime push. The assertion is kept as a permanent regression guard.
- [x] In game 2, round 1 → round 2 transition completes for ALL players within the existing 8s GuessResult window + Scoreboard advance — verified: e2e/rematch.spec.ts:48 plays game 1 to completion, rematches, plays game 2 round 1, then asserts both host and guest see `Round 2/2` (which would never appear on `main` due to Bug #2).
- [x] Both regressions fixed in a single PR — single PR; Bug #1 documented as not-reproduced, Bug #2 fixed at app/room/[code]/playing.tsx:88-122.
- [x] PR description identifies the root cause for each bug — see Root cause analysis section below.
- [x] No regression to PR #4 (lobby host settings + Phase 1 scoring guard) or PR #5 (GuessResult Correct/Foul transient, 8s + tap-to-skip) — verified: full Playwright suite (12 specs, all pass) including lobby-settings.spec.ts (PR #4 surface) and full-game.spec.ts (PR #5 surface). Vitest 44 unit tests all pass.
- [x] Happy path — verified: e2e/rematch.spec.ts:48 (host configures Rounds=2; play game 1; rematch; lobby still shows Rounds=2; start game 2; round 1 result → Scoreboard → auto-advance to round 2 NameCard for both players).
- [x] Error state (foul-ended rematch) — verified: e2e/rematch.spec.ts:132 (1-round game, both players foul, rematch lobby still shows Rounds=1 with category locked, game 2 round 1 NameCard appears for both).

Groomed rubric: https://github.com/adisak1618/footballer-guesser/issues/7#issuecomment-4350638674

Generated with [Claude Code](https://claude.com/claude-code)
