### PR TITLE
fix(lobby): unlock category selector after rematch (#14)

### DIFF
--- a/apps/headball/e2e/rematch.spec.ts
+++ b/apps/headball/e2e/rematch.spec.ts
@@ -92,14 +92,15 @@ test("rematch preserves lobby settings and advances rounds in game 2", async ({
     await expect(hostPage.locator("#lobby-rounds")).toHaveValue("2")
     await expect(guestPage.locator("#lobby-rounds")).toHaveValue("2")
 
-    // Category select reflects the locked-after-game-1 value.
-    // Default is 'worldwide-stars' (per migration 0012); host did not change
-    // it before starting game 1, so that's what gets locked in.
+    // Category select reflects the previously played value (default
+    // 'worldwide-stars' per migration 0012; host did not change it before
+    // game 1).
     await expect(hostPage.locator("#lobby-category")).toHaveValue(
       "worldwide-stars",
     )
-    // Once any round has been played, category select is disabled (locked).
-    await expect(hostPage.locator("#lobby-category")).toBeDisabled()
+    // Issue #14: after rematch, the category selector must be enabled again
+    // so players can pick a different category for the next game.
+    await expect(hostPage.locator("#lobby-category")).toBeEnabled()
 
     // Bug #2: Start game 2 and verify round 1 → round 2 advance.
     await startGameAsHost(hostPage)
@@ -173,7 +174,18 @@ test("rematch after foul-ended round persists settings and advances rounds", asy
     await expect(hostPage.locator("#lobby-rounds")).toHaveValue("1", {
       timeout: 15_000,
     })
-    await expect(hostPage.locator("#lobby-category")).toBeDisabled()
+    // Issue #14: category selector must be interactive on the post-rematch
+    // lobby so the host can pick a different category for game 2.
+    await expect(hostPage.locator("#lobby-category")).toBeEnabled()
+    await hostPage.locator("#lobby-category").selectOption("premier-league")
+    await expect(hostPage.locator("#lobby-category")).toHaveValue(
+      "premier-league",
+    )
+    await hostPage.getByTestId("lobby-settings-save").click()
+    await expect(guestPage.locator("#lobby-category")).toHaveValue(
+      "premier-league",
+      { timeout: 10_000 },
+    )
 
     // Game 2 starts and round 1 reaches NameCard for both players (Bug #2
     // would have stalled this on the post-rematch refetch race).

--- a/apps/headball/lib/__tests__/reset-game-unlocks-category.test.ts
+++ b/apps/headball/lib/__tests__/reset-game-unlocks-category.test.ts
@@ -1,0 +1,141 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { createClient } from "@supabase/supabase-js"
+
+// Integration test for issue #14: reset_game must clear `category_locked`
+// so the host can pick a different category for the next game. Requires
+// `bunx supabase start` running locally. Mirrors the service-role-client
+// pattern from `insider-secret-rls.test.ts`.
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL ?? "http://127.0.0.1:54321"
+
+const LOCAL_SERVICE_ROLE_FALLBACK =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+  "eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0." +
+  "EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU"
+
+const SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ?? LOCAL_SERVICE_ROLE_FALLBACK
+
+const TEST_ROOM_CODE = "RST014"
+const HOST_PLAYER_ID = "00000000-0000-4000-a000-000000000014"
+const GUEST_PLAYER_ID = "00000000-0000-4000-a000-000000000015"
+
+const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+  auth: { persistSession: false, autoRefreshToken: false },
+})
+
+let roomId: string
+
+async function seedEndedRoom() {
+  await admin.from("rooms").delete().eq("code", TEST_ROOM_CODE)
+
+  const { data: room, error: roomErr } = await admin
+    .from("rooms")
+    .insert({
+      code: TEST_ROOM_CODE,
+      status: "ENDED",
+      current_round: 3,
+      max_rounds: 3,
+      score_positions: 1,
+      category: "premier-league",
+      category_locked: true,
+      host_player_id: HOST_PLAYER_ID,
+    })
+    .select("id")
+    .single()
+  expect(roomErr).toBeNull()
+  expect(room?.id).toBeTruthy()
+  roomId = room!.id as string
+
+  const { error: hostErr } = await admin.from("players").insert([
+    {
+      room_id: roomId,
+      player_id: HOST_PLAYER_ID,
+      display_name: "Host",
+      join_order: 1,
+      total_score: 5,
+    },
+    {
+      room_id: roomId,
+      player_id: GUEST_PLAYER_ID,
+      display_name: "Guest",
+      join_order: 2,
+      total_score: 3,
+    },
+  ])
+  expect(hostErr).toBeNull()
+
+  const { error: stateErr } = await admin.from("round_state").insert({
+    room_id: roomId,
+    round_number: 3,
+    player_id: HOST_PLAYER_ID,
+    assigned_name: "Lionel Messi",
+    score_this_round: 1,
+    is_active: false,
+    final_position: 1,
+  })
+  expect(stateErr).toBeNull()
+
+  const { error: posErr } = await admin.from("round_positions").insert({
+    room_id: roomId,
+    round_number: 3,
+    next_position: 2,
+  })
+  expect(posErr).toBeNull()
+}
+
+beforeAll(async () => {
+  await seedEndedRoom()
+})
+
+afterAll(async () => {
+  await admin.from("rooms").delete().eq("code", TEST_ROOM_CODE)
+})
+
+describe("reset_game unlocks category (issue #14)", () => {
+  it("flips status ENDED → LOBBY, clears category_locked, resets game-state, preserves room code + category", async () => {
+    const { error } = await admin.rpc("reset_game", {
+      p_room_id: roomId,
+      p_host_player_id: HOST_PLAYER_ID,
+    })
+    expect(error).toBeNull()
+
+    const { data: room, error: readErr } = await admin
+      .from("rooms")
+      .select(
+        "code, status, current_round, category, category_locked, host_player_id",
+      )
+      .eq("id", roomId)
+      .single()
+
+    expect(readErr).toBeNull()
+    expect(room?.code).toBe(TEST_ROOM_CODE)
+    expect(room?.status).toBe("LOBBY")
+    expect(room?.current_round).toBe(0)
+    expect(room?.category).toBe("premier-league")
+    expect(room?.category_locked).toBe(false)
+    expect(room?.host_player_id).toBe(HOST_PLAYER_ID)
+
+    const { data: players, error: playersErr } = await admin
+      .from("players")
+      .select("player_id, total_score")
+      .eq("room_id", roomId)
+      .order("join_order")
+    expect(playersErr).toBeNull()
+    expect(players).toHaveLength(2)
+    expect(players?.every((p) => p.total_score === 0)).toBe(true)
+
+    const { count: stateCount } = await admin
+      .from("round_state")
+      .select("*", { count: "exact", head: true })
+      .eq("room_id", roomId)
+    expect(stateCount).toBe(0)
+
+    const { count: posCount } = await admin
+      .from("round_positions")
+      .select("*", { count: "exact", head: true })
+      .eq("room_id", roomId)
+    expect(posCount).toBe(0)
+  })
+})

--- a/supabase/migrations/0034_reset_game_unlock_category.sql
+++ b/supabase/migrations/0034_reset_game_unlock_category.sql
@@ -1,0 +1,49 @@
+-- 0034_reset_game_unlock_category: when the host returns the room from ENDED
+-- to LOBBY, also clear `category_locked` so players can pick a different
+-- category for the next game. Issue #14: Category selector was stuck disabled
+-- after the first game ended because 0006_reset_game.sql never reset the flag
+-- that 0007_lobby_settings.sql / start_game flips on first start.
+
+create or replace function reset_game(
+  p_room_id uuid,
+  p_host_player_id uuid
+) returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_host   uuid;
+  v_status room_status;
+begin
+  select host_player_id, status
+    into v_host, v_status
+  from rooms where id = p_room_id
+  for update;
+
+  if v_host is null then
+    raise exception 'room not found' using errcode = 'P0002';
+  end if;
+  if v_host <> p_host_player_id then
+    raise exception 'not host' using errcode = 'P0005';
+  end if;
+  if v_status <> 'ENDED' then
+    raise exception 'room not ended' using errcode = 'P0009';
+  end if;
+
+  delete from round_events    where room_id = p_room_id;
+  delete from round_state     where room_id = p_room_id;
+  delete from round_positions where room_id = p_room_id;
+
+  update players set total_score = 0 where room_id = p_room_id;
+
+  update rooms
+     set status          = 'LOBBY',
+         current_round   = 0,
+         category_locked = false
+   where id = p_room_id;
+end;
+$$;
+
+revoke execute on function reset_game(uuid, uuid) from public;
+grant execute on function reset_game(uuid, uuid) to anon;


### PR DESCRIPTION
## Summary
After a Headball game ends, the lobby's Category selector was stuck disabled even after clicking 'เล่นรอบใหม่' — `reset_game` zeroed scores and round state but never cleared the `category_locked` flag that `start_game` had flipped on first start. Players couldn't pick a different category for the next game. Fix: `reset_game` now also sets `category_locked = false`.

Fixes #14

## Changes
- `supabase/migrations/0034_reset_game_unlock_category.sql` — replaces the `reset_game` function so the same UPDATE that flips status back to LOBBY also clears `category_locked`. Signature unchanged; `packages/types/src/database.types.ts` did not need a regenerate.
- `apps/headball/lib/__tests__/reset-game-unlocks-category.test.ts` — new vitest integration test against the local Supabase: seeds an ENDED room with `category_locked=true`, populated `round_state` / `round_positions`, and `players.total_score>0`; calls the RPC; asserts status=LOBBY, `category_locked=false`, current_round=0, all scores zeroed, child rows deleted, and code + host_player_id preserved.
- `apps/headball/e2e/rematch.spec.ts` — flips the existing post-rematch assertions from `#lobby-category` `toBeDisabled()` → `toBeEnabled()` (the prior tests encoded the bug). The rounds=1 / foul-ended test now also picks a different category ('premier-league') after rematch and verifies the change replicates to the guest via Realtime before starting game 2.

## Rubric verification
- [x] Clicking 'เล่นรอบใหม่' (the actual UI copy; rubric wrote 'เล่นเกมใหม่') routes back to the lobby of the same room — verified: e2e `rematch.spec.ts` clicks the button, room code is preserved, both clients land on `#lobby-rounds` (PASS).
- [x] Category selector is ENABLED on lobby return — verified: (1) e2e `rematch.spec.ts` asserts `#lobby-category` is enabled (was previously asserting `toBeDisabled` — flipped); (2) browser QA on /room/KR4BJ8 with seeded ENDED+category_locked=true → ran `reset_game` RPC → `document.getElementById('lobby-category').disabled === false` and no disabled attribute on the element (PASS).
- [x] Game-state (score, used players, round counter) reset; players remain in same room — verified: vitest `reset-game-unlocks-category.test.ts` asserts `current_round=0`, all `players.total_score=0`, `round_state` and `round_positions` rows for the room are deleted, `code` and `host_player_id` preserved (PASS).
- [x] Behavior holds regardless of category — verified: fix is at the SQL level (`reset_game` always sets `category_locked=false` regardless of which category was played); not category-specific (PASS).
- [x] No regression to the other 3 lobby selectors — verified: `bunx vitest run` 59/59 pass; `bunx playwright test` 14/14 pass including `lobby-settings.spec.ts` covering rounds + Top-N + difficulty; `rematch.spec.ts` asserts rounds + category value persist after rematch (PASS).
- [x] Vitest unit test asserts post-game lobby exposes Category as enabled and resets game-state while preserving the room code — verified: new `reset-game-unlocks-category.test.ts` seeds an ENDED room with `category_locked=true`, calls the RPC, asserts status=LOBBY, category_locked=false, current_round=0, total_score=0 for both players, room code preserved (PASS).
- [x] Playwright E2E spec reproduces end-game with rounds=1, clicks 'เล่นรอบใหม่', and asserts Category selector is interactive — verified: `rematch after foul-ended round persists settings and advances rounds` test sets rounds=1, finishes via foul, clicks 'เล่นรอบใหม่', asserts `#lobby-category` enabled, selectOption('premier-league'), guest sees update via Realtime, game 2 starts (PASS).
- [x] Happy path: finish rounds=1 game → click 'เล่นรอบใหม่' → land on lobby for same room → Category enabled → pick a different category → start new game — verified: `rematch after foul-ended round` e2e exercises this exact flow end-to-end and starts game 2 successfully on the new category (PASS).

Note: rubric quotes the end-game CTA copy as เล่นเกมใหม่ but the actual button label is เล่นรอบใหม่ (in `app/room/[code]/results.tsx` and the existing e2e helpers). Same button, no fix needed for the copy.

Groomed rubric: https://github.com/adisak1618/footballer-guesser/issues/14#issuecomment-4413020775

## Test plan
- [x] `bun run lint` — pass
- [x] `bunx tsc --noEmit` — pass
- [x] `bun run build` — pass
- [x] `bunx vitest run` — 59/59 pass (incl. new reset-game-unlocks-category test)
- [x] `PORT=3014 bunx playwright test` — 14/14 pass (incl. updated rematch specs)
- [x] Browser QA on /room/<code> with seeded ENDED+category_locked=true → reset_game RPC → `lobby-category` is enabled (no disabled attribute, opacity 1)

Generated with [Claude Code](https://claude.com/claude-code)
