### PR TITLE
feat(game): hide hero name + lock guess popup + remove ดูคะแนน (#13)

### DIFF
--- a/apps/headball/components/guess-modal.tsx
+++ b/apps/headball/components/guess-modal.tsx
@@ -45,15 +45,15 @@ interface GuessModalProps {
   roomId: string
   roundNumber: number
   playerId: string
-  onCancel: () => void
   onResult: (result: { correct: boolean; score: number }) => void
 }
+
+const GUESS_MODAL_HISTORY_FLAG = "headballGuessModalOpen"
 
 export function GuessModal({
   roomId,
   roundNumber,
   playerId,
-  onCancel,
   onResult,
 }: GuessModalProps) {
   const [text, setText] = useState("")
@@ -74,13 +74,41 @@ export function GuessModal({
     queueMicrotask(() => inputRef.current?.focus())
   }, [])
 
+  // Lock dismissal: ESC + browser-back are both blocked while the modal is
+  // mounted. The modal can only be closed by submitting a guess (which calls
+  // onResult and unmounts us). Backdrop click and the ยกเลิก button were
+  // removed entirely from the render tree.
   useEffect(() => {
     function onKey(event: KeyboardEvent) {
-      if (event.key === "Escape" && !isPending) onCancel()
+      if (event.key === "Escape") {
+        event.preventDefault()
+        event.stopPropagation()
+      }
     }
-    window.addEventListener("keydown", onKey)
-    return () => window.removeEventListener("keydown", onKey)
-  }, [isPending, onCancel])
+    // Capture phase so we beat any document-level handler.
+    window.addEventListener("keydown", onKey, true)
+    return () => window.removeEventListener("keydown", onKey, true)
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    // Push a sentinel state so the next browser-back lands on us instead of
+    // navigating away. On popstate, immediately re-push so we stay locked.
+    window.history.pushState({ [GUESS_MODAL_HISTORY_FLAG]: true }, "")
+    function onPopState() {
+      window.history.pushState({ [GUESS_MODAL_HISTORY_FLAG]: true }, "")
+    }
+    window.addEventListener("popstate", onPopState)
+    return () => {
+      window.removeEventListener("popstate", onPopState)
+      // Clean up: if our sentinel is still on top of the stack (modal closed
+      // via submit, not via back), pop it so the user's history isn't padded.
+      const state = window.history.state as Record<string, unknown> | null
+      if (state && state[GUESS_MODAL_HISTORY_FLAG]) {
+        window.history.back()
+      }
+    }
+  }, [])
 
   function dispatchSubmit(value: string) {
     setNetworkError(null)
@@ -146,16 +174,11 @@ export function GuessModal({
     dispatchSubmit(parsed.data)
   }
 
-  function onBackdrop(event: React.MouseEvent<HTMLDivElement>) {
-    if (event.target === event.currentTarget && !isPending) onCancel()
-  }
-
   return (
     <div
       role="dialog"
       aria-modal="true"
       aria-label="ทายชื่อนักเตะของคุณ"
-      onClick={onBackdrop}
       className="fixed inset-0 z-50 flex items-end justify-center bg-black/70 px-4 pb-6 pt-10 sm:items-center"
     >
       <form
@@ -244,19 +267,11 @@ export function GuessModal({
           </div>
         ) : null}
 
-        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-          <button
-            type="button"
-            onClick={onCancel}
-            disabled={isPending}
-            className="inline-flex min-h-11 items-center justify-center rounded-xl border border-hairline bg-surface-elevated px-5 text-sm font-medium text-on-dark disabled:opacity-60"
-          >
-            ยกเลิก
-          </button>
+        <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
           <button
             type="submit"
             disabled={isPending}
-            className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-goal px-6 text-sm font-semibold text-on-dark active:bg-goal-active disabled:opacity-60"
+            className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-xl bg-goal px-6 text-sm font-semibold text-on-dark active:bg-goal-active disabled:opacity-60 sm:w-auto"
           >
             {showSpinner ? (
               <span

--- a/apps/headball/components/name-card.tsx
+++ b/apps/headball/components/name-card.tsx
@@ -37,7 +37,6 @@ interface NameCardProps {
   round: number
   maxRounds: number
   myRoundState: RoundState | null
-  onScores?: () => void
 }
 
 export function NameCard({
@@ -46,7 +45,6 @@ export function NameCard({
   round,
   maxRounds,
   myRoundState,
-  onScores,
 }: NameCardProps) {
   const [overlayOpen, setOverlayOpen] = useState(false)
   const [guessOpen, setGuessOpen] = useState(false)
@@ -98,15 +96,14 @@ export function NameCard({
   const tagBg = TAG_BG[me.join_order] ?? "bg-tag-red"
   const tagText = TAG_TEXT[me.join_order] ?? "text-on-dark"
   const upperName = myRoundState.assigned_name.toUpperCase()
+  const heroDisplay = guessOpen ? "???" : upperName
+  const heroAriaLabel = guessOpen
+    ? "ชื่อของคุณถูกซ่อน — กำลังทาย"
+    : "ชื่อของคุณซ่อนอยู่ — หันจอให้เพื่อนเห็นเพื่อเริ่มเล่น"
 
   function handleGuessTap() {
     setOverlayOpen(false)
     setGuessOpen(true)
-  }
-
-  function handleScoresTap() {
-    setOverlayOpen(false)
-    onScores?.()
   }
 
   function handleGuessResult({ correct }: { correct: boolean; score: number }) {
@@ -118,7 +115,7 @@ export function NameCard({
     <>
       <main
         role="img"
-        aria-label="ชื่อของคุณซ่อนอยู่ — หันจอให้เพื่อนเห็นเพื่อเริ่มเล่น"
+        aria-label={heroAriaLabel}
         className={`relative flex min-h-[100dvh] w-full select-none flex-col items-center justify-center overflow-hidden px-6 text-center ${tagBg} ${tagText} ${
           feedback === "foul" ? "motion-safe:animate-hb-shake" : ""
         }`}
@@ -126,8 +123,11 @@ export function NameCard({
         <p className="absolute left-4 top-4 text-xs font-semibold uppercase tracking-[0.5px] opacity-80">
           Round {round}/{maxRounds}
         </p>
-        <span className="font-hero text-[96px] leading-[0.95] tracking-[2px] min-[375px]:text-[144px]">
-          {upperName}
+        <span
+          data-testid="hero-name"
+          className="font-hero text-[96px] leading-[0.95] tracking-[2px] min-[375px]:text-[144px]"
+        >
+          {heroDisplay}
         </span>
         <p className="absolute inset-x-0 bottom-6 text-xs font-medium uppercase tracking-[0.5px] opacity-80">
           — tap to act —
@@ -143,7 +143,6 @@ export function NameCard({
         <TurnOverlay
           onCancel={() => setOverlayOpen(false)}
           onGuess={handleGuessTap}
-          onScores={handleScoresTap}
         />
       ) : null}
       {guessOpen ? (
@@ -151,7 +150,6 @@ export function NameCard({
           roomId={roomId}
           roundNumber={round}
           playerId={me.player_id}
-          onCancel={() => setGuessOpen(false)}
           onResult={handleGuessResult}
         />
       ) : null}

--- a/apps/headball/components/name-card.tsx
+++ b/apps/headball/components/name-card.tsx
@@ -96,8 +96,12 @@ export function NameCard({
   const tagBg = TAG_BG[me.join_order] ?? "bg-tag-red"
   const tagText = TAG_TEXT[me.join_order] ?? "text-on-dark"
   const upperName = myRoundState.assigned_name.toUpperCase()
-  const heroDisplay = guessOpen ? "???" : upperName
-  const heroAriaLabel = guessOpen
+  // Hide the name once the player has tapped to act — both the turn overlay
+  // (which uses a 95%-opacity backdrop, so the BIG NAME bleeds through) and
+  // the guess popup must show ??? instead of the assigned name.
+  const nameHidden = overlayOpen || guessOpen
+  const heroDisplay = nameHidden ? "???" : upperName
+  const heroAriaLabel = nameHidden
     ? "ชื่อของคุณถูกซ่อน — กำลังทาย"
     : "ชื่อของคุณซ่อนอยู่ — หันจอให้เพื่อนเห็นเพื่อเริ่มเล่น"
 

--- a/apps/headball/components/turn-overlay.tsx
+++ b/apps/headball/components/turn-overlay.tsx
@@ -7,10 +7,9 @@ const AUTO_DISMISS_MS = 10000
 interface TurnOverlayProps {
   onCancel: () => void
   onGuess: () => void
-  onScores: () => void
 }
 
-export function TurnOverlay({ onCancel, onGuess, onScores }: TurnOverlayProps) {
+export function TurnOverlay({ onCancel, onGuess }: TurnOverlayProps) {
   const [secondsLeft, setSecondsLeft] = useState(Math.ceil(AUTO_DISMISS_MS / 1000))
   const [visible, setVisible] = useState(false)
 
@@ -76,14 +75,6 @@ export function TurnOverlay({ onCancel, onGuess, onScores }: TurnOverlayProps) {
           >
             <span aria-hidden="true">⚽</span>
             ทายชื่อ
-          </button>
-          <button
-            type="button"
-            onClick={onScores}
-            className="flex min-h-11 w-full items-center justify-center gap-2 rounded-2xl border border-hairline bg-surface-elevated px-6 text-sm font-medium text-on-dark"
-          >
-            <span aria-hidden="true">🏆</span>
-            ดูคะแนน
           </button>
         </div>
 

--- a/apps/headball/e2e/guess-popup-lock.spec.ts
+++ b/apps/headball/e2e/guess-popup-lock.spec.ts
@@ -59,7 +59,9 @@ test("guess popup hides hero name, locks dismissal, and scoreboard auto-shows af
     })
 
     // Open the turn overlay and confirm the standalone ดูคะแนน button
-    // is gone (acceptance #3).
+    // is gone (acceptance #3). The TurnOverlay uses a 95%-opacity backdrop,
+    // so the hero text bleeds through — it must be hidden the moment the
+    // overlay opens, not just when the guess popup opens.
     const tapTarget = hostPage.getByRole("button", {
       name: "แตะเพื่อเปิดตัวเลือก",
     })
@@ -69,6 +71,7 @@ test("guess popup hides hero name, locks dismissal, and scoreboard auto-shows af
     })
     await expect(turnOverlay).toBeVisible()
     await expect(turnOverlay.getByRole("button", { name: /ดูคะแนน/ })).toHaveCount(0)
+    await expect(heroSpan).toHaveText("???")
 
     // Open the guess popup. The hero name on the underlying screen must
     // swap to ??? (acceptance #1, not blurred / not overlaid).

--- a/apps/headball/e2e/guess-popup-lock.spec.ts
+++ b/apps/headball/e2e/guess-popup-lock.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from "@playwright/test"
+import { createRoom, joinRoom, startGameAsHost } from "./_helpers/flow"
+import {
+  adminClient,
+  getRoomIdByCode,
+  setMaxRounds,
+} from "./_helpers/admin"
+
+// Issue #13: when the guesser opens the guess popup
+//   1. The hero name on the BIG NAME card is replaced with `???` (no overlay).
+//   2. The popup cannot be dismissed by ESC, backdrop click, or browser back.
+//   3. The standalone ดูคะแนน button is gone from the in-turn UI.
+//   4. After submit, the popup closes and the scoreboard becomes visible
+//      while the round continues for other players.
+
+test("guess popup hides hero name, locks dismissal, and scoreboard auto-shows after submit", async ({
+  browser,
+}) => {
+  const hostCtx = await browser.newContext()
+  const hostPage = await hostCtx.newPage()
+  const guestCtx = await browser.newContext()
+  const guestPage = await guestCtx.newPage()
+
+  try {
+    const code = await createRoom(hostPage, "Host")
+    await joinRoom(guestPage, code, "Guest")
+    await setMaxRounds(code, 2)
+    await startGameAsHost(hostPage)
+
+    await expect(hostPage.getByText("Round 1/2").first()).toBeVisible({
+      timeout: 20_000,
+    })
+    await expect(guestPage.getByText("Round 1/2").first()).toBeVisible({
+      timeout: 20_000,
+    })
+
+    // The host is the guesser in this test. Hero name shows the assigned
+    // football player before the popup opens.
+    const sb = adminClient()
+    const roomId = await getRoomIdByCode(code)
+    const { data: hostPlayer } = await sb
+      .from("players")
+      .select("player_id")
+      .eq("room_id", roomId)
+      .eq("display_name", "Host")
+      .maybeSingle()
+    if (!hostPlayer) throw new Error("host player not found")
+    const { data: rs } = await sb
+      .from("round_state")
+      .select("assigned_name")
+      .eq("room_id", roomId)
+      .eq("player_id", hostPlayer.player_id)
+      .eq("round_number", 1)
+      .maybeSingle()
+    if (!rs) throw new Error("round_state not found")
+    const heroSpan = hostPage.getByTestId("hero-name")
+    await expect(heroSpan).toHaveText(rs.assigned_name.toUpperCase(), {
+      timeout: 10_000,
+    })
+
+    // Open the turn overlay and confirm the standalone ดูคะแนน button
+    // is gone (acceptance #3).
+    const tapTarget = hostPage.getByRole("button", {
+      name: "แตะเพื่อเปิดตัวเลือก",
+    })
+    await tapTarget.click()
+    const turnOverlay = hostPage.getByRole("dialog", {
+      name: "ตัวเลือกของผู้เล่น",
+    })
+    await expect(turnOverlay).toBeVisible()
+    await expect(turnOverlay.getByRole("button", { name: /ดูคะแนน/ })).toHaveCount(0)
+
+    // Open the guess popup. The hero name on the underlying screen must
+    // swap to ??? (acceptance #1, not blurred / not overlaid).
+    await turnOverlay.getByRole("button", { name: /ทายชื่อ/ }).click()
+    const guessModal = hostPage.getByRole("dialog", {
+      name: "ทายชื่อนักเตะของคุณ",
+    })
+    await expect(guessModal).toBeVisible()
+    await expect(heroSpan).toHaveText("???")
+
+    // The popup is locked: ESC, backdrop click, and browser back must NOT
+    // dismiss it (acceptance #2).
+    await hostPage.keyboard.press("Escape")
+    await expect(guessModal).toBeVisible()
+    await expect(heroSpan).toHaveText("???")
+
+    // Backdrop click — the dialog wrapper covers the full viewport; clicking
+    // a corner outside the form should be a no-op now that onBackdrop is gone.
+    await hostPage.mouse.click(5, 5)
+    await expect(guessModal).toBeVisible()
+    await expect(heroSpan).toHaveText("???")
+
+    // Browser back — popstate handler re-pushes the sentinel state, so we
+    // stay on the popup.
+    await hostPage.goBack({ waitUntil: "commit" }).catch(() => {})
+    await expect(guessModal).toBeVisible({ timeout: 5_000 })
+    await expect(heroSpan).toHaveText("???")
+
+    // Submit a correct guess. The popup closes and the scoreboard appears
+    // while the guest is still playing (acceptance #6).
+    await guessModal.locator("#guess-input").fill(rs.assigned_name)
+    await guessModal.getByRole("button", { name: /ส่งคำตอบ/ }).click()
+    await expect(guessModal).toBeHidden({ timeout: 10_000 })
+
+    // After the GuessResult auto-advance (8s) or by tap, the scoreboard's
+    // waiting copy shows. Tap-to-skip to keep the test fast.
+    const guessResult = hostPage.getByRole("status", { name: "ทายถูก" })
+    if (await guessResult.isVisible().catch(() => false)) {
+      await guessResult.getByLabel("ข้ามไปสกอร์บอร์ด").click()
+    }
+    await expect(hostPage.getByText(/รอผู้เล่นคนอื่น/)).toBeVisible({
+      timeout: 15_000,
+    })
+  } finally {
+    await hostCtx.close()
+    await guestCtx.close()
+  }
+})

--- a/apps/headball/lib/__tests__/name-card.test.tsx
+++ b/apps/headball/lib/__tests__/name-card.test.tsx
@@ -68,6 +68,15 @@ describe("NameCard hero name reveal", () => {
     expect(hero.textContent).toBe("STEVEN GERRARD")
   })
 
+  it("swaps the hero text to ??? when the turn overlay is open", () => {
+    setup()
+    fireEvent.click(screen.getByLabelText("แตะเพื่อเปิดตัวเลือก"))
+
+    const hero = screen.getByTestId("hero-name")
+    expect(hero.textContent).toBe("???")
+    expect(hero.textContent).not.toContain("STEVEN")
+  })
+
   it("swaps the hero text to ??? when the guess popup is open", () => {
     setup()
     fireEvent.click(screen.getByLabelText("แตะเพื่อเปิดตัวเลือก"))

--- a/apps/headball/lib/__tests__/name-card.test.tsx
+++ b/apps/headball/lib/__tests__/name-card.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { NameCard } from "@/components/name-card"
+import type { Player, RoundState } from "@/lib/types"
+
+vi.mock("@/app/actions/submit-guess", () => ({
+  submitGuessAction: vi.fn(),
+}))
+
+if (typeof window !== "undefined" && !window.matchMedia) {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList
+}
+
+const me: Player = {
+  id: "player-row-1",
+  player_id: "p1",
+  room_id: "r1",
+  display_name: "Tester",
+  join_order: 1,
+  total_score: 0,
+  connected: true,
+}
+
+const myRoundState: RoundState = {
+  id: "rs1",
+  room_id: "r1",
+  player_id: "p1",
+  round_number: 1,
+  assigned_name: "Steven Gerrard",
+  is_active: true,
+  is_correct: null,
+  final_position: null,
+  score_this_round: null,
+}
+
+function setup() {
+  return render(
+    <NameCard
+      me={me}
+      roomId="r1"
+      round={1}
+      maxRounds={5}
+      myRoundState={myRoundState}
+    />,
+  )
+}
+
+describe("NameCard hero name reveal", () => {
+  beforeEach(() => {
+    if (typeof window !== "undefined") {
+      window.history.replaceState(null, "")
+    }
+  })
+
+  it("renders the assigned name in the BIG NAME card by default", () => {
+    setup()
+    const hero = screen.getByTestId("hero-name")
+    expect(hero.textContent).toBe("STEVEN GERRARD")
+  })
+
+  it("swaps the hero text to ??? when the guess popup is open", () => {
+    setup()
+    fireEvent.click(screen.getByLabelText("แตะเพื่อเปิดตัวเลือก"))
+    fireEvent.click(screen.getByRole("button", { name: /ทายชื่อ/ }))
+
+    const hero = screen.getByTestId("hero-name")
+    expect(hero.textContent).toBe("???")
+    expect(hero.textContent).not.toContain("STEVEN")
+  })
+})


### PR DESCRIPTION
## Summary
Hide the footballer name (swap to `???`) on the BIG NAME card while the guess popup is open, lock the popup so it can only be closed by submitting (no ESC, no backdrop click, no browser back), and remove the standalone ดูคะแนน button from the in-turn UI. The scoreboard now reaches the guesser via the natural game flow only — after submit (`รอผู้เล่นคนอื่น` → scoreboard auto-advance), at end-of-round, and at end-of-game.

Fixes #13

## Changes
- `apps/headball/components/name-card.tsx` — hero text reads `???` when `guessOpen === true` (state already lived on this component); aria-label flips to "ชื่อของคุณถูกซ่อน — กำลังทาย" while hidden. Added `data-testid="hero-name"` for stable test selection. Removed unused `onScores` prop / `handleScoresTap` (the in-turn ดูคะแนน path is gone).
- `apps/headball/components/turn-overlay.tsx` — dropped the `onScores` prop and the ดูคะแนน button. The overlay's own ยกเลิก (cancel) button stays — it cancels the action menu, not the guess popup.
- `apps/headball/components/guess-modal.tsx` — removed `onCancel` prop entirely, deleted the ESC-to-cancel handler, deleted the backdrop-click handler, deleted the ยกเลิก submit-row button. ESC keydown is now caught in capture phase and `preventDefault`-ed. Browser back is blocked via `history.pushState` on mount + a popstate listener that re-pushes the sentinel; on unmount the sentinel is popped via `history.back()` so user history isn't padded.
- `apps/headball/lib/__tests__/name-card.test.tsx` — new vitest spec: renders the assigned name by default, then asserts `???` after the tap-to-act → ทายชื่อ flow opens the popup. Stubs `window.matchMedia` for jsdom.
- `apps/headball/e2e/guess-popup-lock.spec.ts` — new playwright spec: starts a 2-round game, opens the guess popup as host, asserts the standalone ดูคะแนน is gone, hero swaps to `???`, and ESC + backdrop click + `page.goBack()` all leave the popup open. Then submits and asserts `รอผู้เล่นคนอื่น` (scoreboard waiting copy) becomes visible.

## Rubric verification
- [x] BIG NAME card swaps to `???` placeholder while guess popup open (not blurred, not overlaid) — verified via /browse: `document.querySelector('[data-testid="hero-name"]').textContent === "???"` after opening popup; same node, text replaced
- [x] Guess popup cannot be dismissed by backdrop click, ESC, or browser back — verified via /browse: ESC press, click at (5,5), and `history.back()` each left dialog open and hero text `???`
- [x] Standalone ดูคะแนน button removed from in-turn UI — verified via /browse: TurnOverlay snapshot lists only ทายชื่อ + cancel("ยกเลิก" for the overlay itself, not the popup); no ดูคะแนน button
- [x] Scoreboard auto-shows at end-of-round — verified via /browse: after both players submit R1, both pages auto-advanced to R2 NameCard (between-round scoreboard surfaced naturally during inactive interval, then next_round was triggered)
- [x] Scoreboard auto-shows at end-of-game — verified via /browse: after both submit R2 of 2-round game, both pages show "จบเกม / Final Score" results screen with no manual action required
- [x] Scoreboard auto-shows for the guesser after they submit — verified via /browse: host submitted, popup closed, GuessResult appeared with "รอผู้เล่นคนอื่น...", auto-advance/tap-to-skip surfaced "Scoreboard" while guest still active
- [x] Name placeholder + popup lock + scoreboard visibility apply on guesser device only — verified: changes touch only client-side state in NameCard / GuessModal / TurnOverlay; no Supabase schema, RPC, or realtime subscription changes

**States verified:**
- [x] Happy path — verified above (guesser tap → ??? swap → locked popup → submit → scoreboard)
- [x] Loading state: N/A per rubric
- [x] Empty state: N/A per rubric
- [x] Error state (dismiss attempts) — verified: ESC + backdrop click + browser back all left popup open with hero `???`

**Test plan:**
- [x] Vitest unit test `apps/headball/lib/__tests__/name-card.test.tsx` — renders `STEVEN GERRARD`, then after open-popup interaction renders `???` (2 tests passing)
- [x] Playwright E2E spec `apps/headball/e2e/guess-popup-lock.spec.ts` — exercises full flow: ESC + (5,5) backdrop click + `page.goBack()` all blocked, submit closes popup, scoreboard "รอผู้เล่นคนอื่น" surfaces (passes on port 3113)
- [x] All 60 vitest tests pass (`bunx vitest run`)
- [x] Lint, typecheck, and build all green
- [⚠] Playwright suite: 13/15 pass; 2 rematch failures (`rematch.spec.ts:48`, `rematch.spec.ts:134`) on `#lobby-category` toBeDisabled — pre-existing bug fixed on parallel branch `fix/14-lobby-category-disabled-after-game-end` (commit a22d0fa, not yet on main); unrelated to issue #13 surface area

Groomed rubric: https://github.com/adisak1618/footballer-guesser/issues/13#issuecomment-4413020730

Generated with [Claude Code](https://claude.com/claude-code)
