### PR TITLE
feat(insider): between-rounds + game-end UX (category change, reset, final scoreboard) (#24)

### DIFF
--- a/apps/insider/app/actions/change-insider-pack.ts
+++ b/apps/insider/app/actions/change-insider-pack.ts
@@ -1,0 +1,57 @@
+"use server"
+
+import { z } from "zod"
+import { GameRpcError } from "@social-hub/core"
+import { changeInsiderPack } from "@/lib/insider-rpc"
+import { createSupabaseServerClient } from "@/lib/supabase-server"
+
+// Issue #24 — server action wrapping change_insider_pack RPC (migration 0036).
+// Called by the host's between-rounds pack chips on the Insider lobby.
+
+const inputSchema = z.object({
+  roomId: z.uuid("รหัสห้องไม่ถูกต้อง"),
+  playerId: z.uuid("รหัสผู้เล่นไม่ถูกต้อง"),
+  packSlug: z.string().min(1, "เลือกคลังคำก่อนนะ"),
+})
+
+export type ChangeInsiderPackActionInput = z.input<typeof inputSchema>
+
+export type ChangeInsiderPackActionResult =
+  | { ok: true }
+  | { ok: false; error: string }
+
+function mapError(error: unknown): string {
+  if (error instanceof GameRpcError) {
+    switch (error.code) {
+      case "PG004":
+        return "ห้องไม่พบ"
+      case "PG012":
+        return "เฉพาะโฮสต์เปลี่ยนคลังคำได้"
+      case "PG013":
+        return "เปลี่ยนคลังคำได้เฉพาะระหว่างรอบ"
+      case "PG020":
+        return "ไม่พบคลังคำ"
+      default:
+        return "เปลี่ยนคลังคำไม่สำเร็จ ลองใหม่"
+    }
+  }
+  return "เปลี่ยนคลังคำไม่สำเร็จ ลองใหม่"
+}
+
+export async function changeInsiderPackAction(
+  input: ChangeInsiderPackActionInput,
+): Promise<ChangeInsiderPackActionResult> {
+  const parsed = inputSchema.safeParse(input)
+  if (!parsed.success) {
+    const message = parsed.error.issues[0]?.message ?? "ข้อมูลไม่ถูกต้อง"
+    return { ok: false, error: message }
+  }
+
+  const supabase = createSupabaseServerClient()
+  try {
+    await changeInsiderPack(supabase, parsed.data)
+    return { ok: true }
+  } catch (error) {
+    return { ok: false, error: mapError(error) }
+  }
+}

--- a/apps/insider/app/actions/reset-insider-game.ts
+++ b/apps/insider/app/actions/reset-insider-game.ts
@@ -1,0 +1,55 @@
+"use server"
+
+import { z } from "zod"
+import { GameRpcError } from "@social-hub/core"
+import { resetInsiderGame } from "@/lib/insider-rpc"
+import { createSupabaseServerClient } from "@/lib/supabase-server"
+
+// Issue #24 — server action wrapping reset_insider_game RPC (migration 0037).
+// Called by the host's RESET GAME button between rounds and the
+// PLAY AGAIN / BACK TO LOBBY CTAs on the FinalScoreboard.
+
+const inputSchema = z.object({
+  roomId: z.uuid("รหัสห้องไม่ถูกต้อง"),
+  playerId: z.uuid("รหัสผู้เล่นไม่ถูกต้อง"),
+})
+
+export type ResetInsiderGameActionInput = z.input<typeof inputSchema>
+
+export type ResetInsiderGameActionResult =
+  | { ok: true }
+  | { ok: false; error: string }
+
+function mapError(error: unknown): string {
+  if (error instanceof GameRpcError) {
+    switch (error.code) {
+      case "PG004":
+        return "ห้องไม่พบ"
+      case "PG012":
+        return "เฉพาะโฮสต์รีเซ็ตเกมได้"
+      case "PG013":
+        return "รีเซ็ตเกมได้เฉพาะระหว่างรอบหรือจบเกม"
+      default:
+        return "รีเซ็ตเกมไม่สำเร็จ ลองใหม่"
+    }
+  }
+  return "รีเซ็ตเกมไม่สำเร็จ ลองใหม่"
+}
+
+export async function resetInsiderGameAction(
+  input: ResetInsiderGameActionInput,
+): Promise<ResetInsiderGameActionResult> {
+  const parsed = inputSchema.safeParse(input)
+  if (!parsed.success) {
+    const message = parsed.error.issues[0]?.message ?? "ข้อมูลไม่ถูกต้อง"
+    return { ok: false, error: message }
+  }
+
+  const supabase = createSupabaseServerClient()
+  try {
+    await resetInsiderGame(supabase, parsed.data)
+    return { ok: true }
+  } catch (error) {
+    return { ok: false, error: mapError(error) }
+  }
+}

--- a/apps/insider/app/room/[code]/final-scoreboard.tsx
+++ b/apps/insider/app/room/[code]/final-scoreboard.tsx
@@ -1,0 +1,325 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState, useTransition } from "react"
+import { startInsiderRoundAction } from "@/app/actions/start-insider-round"
+import { resetInsiderGameAction } from "@/app/actions/reset-insider-game"
+import { advanceToReveal } from "@/lib/insider-rpc"
+import { supabase } from "@/lib/supabase"
+
+// Issue #24 — game-end leaderboard. Replaces the standard Reveal screen when
+// `phase ∈ {'reveal','result_failed'}` AND `current_round >= max_rounds`.
+//
+// Permissions: PLAY AGAIN and BACK TO LOBBY are host-only writes (the
+// underlying reset_insider_game RPC + start_insider_round RPC reject non-hosts
+// with PGAME12, but we also gate the buttons client-side so non-hosts see
+// "รอโฮสต์..." copy instead of an error).
+//
+// Surface: dark navy bg + Bebas Neue header (Stadium Energy). 1st-place row
+// uses the player's tag color background and a larger BIG NAME card; 2nd+
+// rows reuse the standard Reveal score-tile treatment for visual continuity.
+
+interface FinalScoreboardPlayer {
+  id: string
+  player_id: string
+  display_name: string
+  join_order: number
+  total_score: number
+}
+
+interface FinalScoreboardProps {
+  roomId: string
+  round: number
+  mePlayerId: string
+  isHost: boolean
+  // Phase is passed through to drive the same scoring fire-on-mount as Reveal
+  // — without it a player who reloads on the final round's result_failed
+  // wouldn't trigger advance_to_reveal idempotency. Both phases are valid.
+  phase: "reveal" | "result_failed"
+}
+
+const TAG_BG_BY_INDEX = [
+  "bg-tag-red",
+  "bg-tag-blue",
+  "bg-tag-yellow",
+  "bg-tag-green",
+  "bg-tag-purple",
+  "bg-tag-orange",
+  "bg-tag-pink",
+  "bg-tag-cyan",
+] as const
+
+const TAG_TEXT_BY_INDEX = [
+  "text-on-dark",
+  "text-on-dark",
+  "text-ink",
+  "text-on-dark",
+  "text-on-dark",
+  "text-on-dark",
+  "text-on-dark",
+  "text-ink",
+] as const
+
+export function FinalScoreboard({
+  roomId,
+  round,
+  mePlayerId,
+  isHost,
+  phase,
+}: FinalScoreboardProps) {
+  const [players, setPlayers] = useState<FinalScoreboardPlayer[]>([])
+  const [scoreError, setScoreError] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [isPending, startAction] = useTransition()
+  const [pendingAction, setPendingAction] = useState<
+    "play-again" | "back-to-lobby" | null
+  >(null)
+
+  // Same advance_to_reveal idempotency seal as the standard Reveal screen.
+  // Reload on the final round must still drive scoring; the RPC short-circuits
+  // on already-scored rounds via scored_at.
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        await advanceToReveal(supabase, { roomId, round })
+        if (!cancelled) setScoreError(null)
+      } catch {
+        if (!cancelled) {
+          setScoreError(
+            "บันทึกผลรอบนี้ไม่สำเร็จ ลองใหม่อีกครั้งหรือเช็คการเชื่อมต่อ",
+          )
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [roomId, round, phase])
+
+  // Initial fetch + realtime: re-pull players when total_score changes (e.g.
+  // the host hits PLAY AGAIN — though by then we'll have routed away).
+  useEffect(() => {
+    let active = true
+    void (async () => {
+      const { data } = await supabase
+        .from("players")
+        .select("id, player_id, display_name, join_order, total_score")
+        .eq("room_id", roomId)
+        .order("join_order", { ascending: true })
+      if (!active) return
+      setPlayers((data ?? []) as FinalScoreboardPlayer[])
+    })()
+    return () => {
+      active = false
+    }
+  }, [roomId])
+
+  useEffect(() => {
+    const channel = supabase
+      .channel(`final-scoreboard-${roomId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "players",
+          filter: `room_id=eq.${roomId}`,
+        },
+        async () => {
+          const { data } = await supabase
+            .from("players")
+            .select("id, player_id, display_name, join_order, total_score")
+            .eq("room_id", roomId)
+            .order("join_order", { ascending: true })
+          if (data) setPlayers(data as FinalScoreboardPlayer[])
+        },
+      )
+      .subscribe()
+    return () => {
+      void supabase.removeChannel(channel)
+    }
+  }, [roomId])
+
+  const sortedPlayers = useMemo(() => {
+    // Sort desc by total_score, then by join_order asc as a stable tie-break
+    // (so refreshes don't reorder players who happen to have equal scores).
+    return [...players].sort((a, b) => {
+      if (b.total_score !== a.total_score) return b.total_score - a.total_score
+      return a.join_order - b.join_order
+    })
+  }, [players])
+
+  const winner = sortedPlayers[0] ?? null
+  const winnerTagIndex = winner ? (winner.join_order - 1) % 8 : 0
+  const winnerTagBg = TAG_BG_BY_INDEX[winnerTagIndex] ?? "bg-tag-red"
+  const winnerTagText = TAG_TEXT_BY_INDEX[winnerTagIndex] ?? "text-on-dark"
+
+  const handlePlayAgain = useCallback(() => {
+    if (!isHost) return
+    setActionError(null)
+    setPendingAction("play-again")
+    startAction(async () => {
+      const reset = await resetInsiderGameAction({ roomId, playerId: mePlayerId })
+      if (!reset.ok) {
+        setActionError(reset.error)
+        setPendingAction(null)
+        return
+      }
+      const start = await startInsiderRoundAction({ roomId, playerId: mePlayerId })
+      if (!start.ok) {
+        setActionError(start.error)
+        setPendingAction(null)
+        return
+      }
+      // On success, the realtime subscription on rooms in lobby.tsx flips
+      // status → PLAYING + current_round → 1 and the screen re-routes to
+      // RoleReveal. No explicit navigation needed.
+    })
+  }, [isHost, roomId, mePlayerId])
+
+  const handleBackToLobby = useCallback(() => {
+    if (!isHost) return
+    setActionError(null)
+    setPendingAction("back-to-lobby")
+    startAction(async () => {
+      const reset = await resetInsiderGameAction({ roomId, playerId: mePlayerId })
+      if (!reset.ok) {
+        setActionError(reset.error)
+        setPendingAction(null)
+        return
+      }
+      // After reset the rooms subscription flips status → LOBBY +
+      // current_round → 0. lobby.tsx re-routes to LobbyView (initial variant
+      // because current_round < 1).
+    })
+  }, [isHost, roomId, mePlayerId])
+
+  return (
+    <main
+      data-testid="insider-final-scoreboard"
+      className="relative mx-auto flex min-h-[100dvh] w-full max-w-[480px] flex-col gap-6 bg-ink px-6 pt-8 pb-10 text-on-dark"
+    >
+      <header className="flex flex-col items-center gap-2 text-center">
+        <h1
+          data-testid="insider-final-header"
+          className="font-display text-[56px] uppercase leading-none tracking-[1px] text-on-dark"
+        >
+          GAME OVER
+        </h1>
+        <p className="font-body text-[14px] text-on-dark-soft">จบเกมแล้ว</p>
+      </header>
+
+      <section className="flex flex-col gap-3" aria-label="Final leaderboard">
+        <p className="text-center font-display text-[12px] uppercase tracking-[2px] text-on-dark-soft">
+          ── FINAL SCORES ──
+        </p>
+        <ol
+          data-testid="insider-final-leaderboard"
+          className="flex flex-col gap-2"
+        >
+          {sortedPlayers.map((p, idx) => {
+            const isFirst = idx === 0
+            const rank = idx + 1
+            if (isFirst) {
+              return (
+                <li
+                  key={p.id}
+                  data-testid={`insider-final-row-${p.player_id}`}
+                  data-rank={rank}
+                  className={`flex flex-col items-center gap-1 rounded-2xl ${winnerTagBg} ${winnerTagText} px-4 py-6 shadow-[0_8px_24px_rgba(0,0,0,0.25)]`}
+                >
+                  <span className="font-display text-[12px] uppercase tracking-[2px] opacity-80">
+                    1ST PLACE
+                  </span>
+                  <span
+                    data-testid="insider-final-winner-name"
+                    className="font-hero text-[64px] leading-[0.95] tracking-[1px]"
+                  >
+                    {p.display_name.toUpperCase()}
+                  </span>
+                  <span
+                    data-testid="insider-final-winner-score"
+                    className="font-display text-[28px] tabular-nums"
+                  >
+                    {p.total_score} pts
+                  </span>
+                </li>
+              )
+            }
+            return (
+              <li
+                key={p.id}
+                data-testid={`insider-final-row-${p.player_id}`}
+                data-rank={rank}
+                className="flex items-center justify-between rounded-lg border border-hairline bg-surface px-4 py-3 text-on-dark"
+              >
+                <span className="flex items-center gap-3">
+                  <span className="font-display text-[14px] tabular-nums text-on-dark-soft">
+                    {rank}
+                  </span>
+                  <span className="font-body text-[14px] font-medium">
+                    {p.display_name}
+                  </span>
+                </span>
+                <span className="font-display text-[18px] tabular-nums">
+                  {p.total_score} pts
+                </span>
+              </li>
+            )
+          })}
+        </ol>
+      </section>
+
+      {scoreError ? (
+        <p
+          role="alert"
+          data-testid="insider-final-score-error"
+          className="rounded-lg border border-error/40 bg-error/10 px-4 py-2 text-center text-sm font-medium text-error"
+        >
+          {scoreError}
+        </p>
+      ) : null}
+
+      {actionError ? (
+        <p
+          role="alert"
+          data-testid="insider-final-action-error"
+          className="rounded-lg border border-error/40 bg-error/10 px-4 py-2 text-center text-sm font-medium text-error"
+        >
+          {actionError}
+        </p>
+      ) : null}
+
+      <div className="mt-auto flex flex-col gap-3">
+        <button
+          type="button"
+          data-testid="insider-final-play-again-cta"
+          onClick={handlePlayAgain}
+          disabled={!isHost || isPending}
+          aria-busy={isPending && pendingAction === "play-again"}
+          aria-disabled={!isHost || isPending}
+          className="flex min-h-14 w-full items-center justify-center rounded-xl bg-goal px-6 font-display text-[20px] uppercase tracking-[1px] text-on-dark transition-colors active:bg-goal-active disabled:bg-goal-disabled disabled:text-on-dark/70"
+        >
+          {pendingAction === "play-again"
+            ? "กำลังเริ่ม..."
+            : isHost
+              ? "PLAY AGAIN →"
+              : "รอโฮสต์เริ่มเกมใหม่"}
+        </button>
+        <button
+          type="button"
+          data-testid="insider-final-back-to-lobby-cta"
+          onClick={handleBackToLobby}
+          disabled={!isHost || isPending}
+          aria-busy={isPending && pendingAction === "back-to-lobby"}
+          aria-disabled={!isHost || isPending}
+          className="flex min-h-14 w-full items-center justify-center rounded-xl border border-hairline bg-surface-elevated px-6 font-display text-[16px] uppercase tracking-[1px] text-on-dark transition-colors active:bg-surface disabled:opacity-60"
+        >
+          {pendingAction === "back-to-lobby"
+            ? "กำลังกลับ..."
+            : "BACK TO LOBBY"}
+        </button>
+      </div>
+    </main>
+  )
+}

--- a/apps/insider/app/room/[code]/lobby.tsx
+++ b/apps/insider/app/room/[code]/lobby.tsx
@@ -9,10 +9,12 @@ import {
   useTransition,
 } from "react"
 import Link from "next/link"
+import type { EnabledPack } from "@social-hub/content"
 import {
   EmptySlot,
   LoadingSkeleton,
   NetworkErrorBanner,
+  PackChip,
   PhaseTransitionOverlay,
   PlayerChip,
   RoomCodeDisplay,
@@ -21,12 +23,15 @@ import {
   useRoomRealtime,
   type RoomRealtimeStatus,
 } from "@social-hub/core"
+import { changeInsiderPackAction } from "@/app/actions/change-insider-pack"
 import { joinInsiderRoomAction } from "@/app/actions/join-insider-room"
+import { resetInsiderGameAction } from "@/app/actions/reset-insider-game"
 import { startInsiderRoundAction } from "@/app/actions/start-insider-round"
 import { getOrCreatePlayerId, readPlayerId } from "@/lib/player-id"
 import { displayNameSchema } from "@/lib/schemas"
 import { supabase } from "@/lib/supabase"
 import { AskingPhase } from "./asking-phase"
+import { FinalScoreboard } from "./final-scoreboard"
 import { Reveal } from "./reveal"
 import { RoleReveal } from "./role-reveal"
 import { Voting } from "./voting"
@@ -53,7 +58,13 @@ interface InsiderRoom {
 const MAX_PLAYERS = 8
 const MIN_PLAYERS_TO_START = 3
 
-export function Lobby({ code }: { code: string }) {
+export function Lobby({
+  code,
+  packs,
+}: {
+  code: string
+  packs: EnabledPack[]
+}) {
   const [room, setRoom] = useState<InsiderRoom | null>(null)
   const [players, setPlayers] = useState<InsiderPlayer[]>([])
   const [meId, setMeId] = useState<string | null>(null)
@@ -250,6 +261,21 @@ export function Lobby({ code }: { code: string }) {
       )
     }
     if (roundPhase === "reveal" || roundPhase === "result_failed") {
+      // Issue #24 — final-round flip: the standard Reveal screen ends the
+      // round normally, but on `current_round >= max_rounds` we render the
+      // FinalScoreboard instead so the host gets PLAY AGAIN / BACK TO LOBBY
+      // instead of "next round" or "match over → home".
+      if (round >= roundTotal) {
+        return shell(
+          <FinalScoreboard
+            roomId={room.id}
+            round={round}
+            mePlayerId={me.player_id}
+            isHost={room.host_player_id === me.player_id}
+            phase={roundPhase}
+          />,
+        )
+      }
       return shell(
         <Reveal
           roomId={room.id}
@@ -276,6 +302,7 @@ export function Lobby({ code }: { code: string }) {
       room={room}
       players={players}
       mePlayerId={me.player_id}
+      packs={packs}
     />,
   )
 }
@@ -428,11 +455,13 @@ function LobbyView({
   room,
   players,
   mePlayerId,
+  packs,
 }: {
   code: string
   room: InsiderRoom
   players: InsiderPlayer[]
   mePlayerId: string
+  packs: EnabledPack[]
 }) {
   const [startError, setStartError] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
@@ -446,6 +475,7 @@ function LobbyView({
   const currentRound = room.current_round ?? 0
   const roundTotal = room.max_rounds
   const isBetweenRounds = currentRound >= 1
+  const isHost = room.host_player_id === mePlayerId
   const nextRound = currentRound + 1
   const startCtaCopy = isPending
     ? "กำลังเริ่ม..."
@@ -481,6 +511,18 @@ function LobbyView({
       </header>
 
       <RoomCodeDisplay code={code} />
+
+      {/* Issue #24 — between-rounds pack control. Host sees editable chips,
+       * non-host sees read-only `Pack: <name>` label. Initial lobby (no
+       * round played yet) keeps the host-setup pack and renders nothing here. */}
+      {isBetweenRounds ? (
+        <BetweenRoundsPackControl
+          roomId={room.id}
+          mePlayerId={mePlayerId}
+          isHost={isHost}
+          packs={packs}
+        />
+      ) : null}
 
       <section className="flex flex-1 flex-col gap-3">
         <h2 className="font-display text-[28px] uppercase leading-none tracking-[0.3px] text-on-dark">
@@ -535,22 +577,327 @@ function LobbyView({
             {startError}
           </p>
         ) : null}
-        <button
-          type="button"
-          onClick={handleStart}
-          disabled={!canStart || isPending}
-          aria-busy={isPending}
-          data-testid="insider-start-game-cta"
-          className="flex min-h-14 w-full items-center justify-center gap-2 rounded-xl bg-goal px-6 text-on-dark transition-colors active:bg-goal-active disabled:bg-goal-disabled disabled:text-on-dark/70"
-        >
-          <span
-            data-testid="insider-start-game-cta-label"
-            className="font-display text-[20px] uppercase tracking-[1px]"
+        {/* Issue #24 — host between-rounds: RESET GAME secondary action sits
+         * to the left of the START ROUND primary CTA. Non-host or initial
+         * lobby never sees it. */}
+        {isBetweenRounds && isHost ? (
+          <div className="flex items-stretch gap-2">
+            <ResetGameButton
+              roomId={room.id}
+              mePlayerId={mePlayerId}
+              disabled={isPending}
+            />
+            <button
+              type="button"
+              onClick={handleStart}
+              disabled={!canStart || isPending}
+              aria-busy={isPending}
+              data-testid="insider-start-game-cta"
+              className="flex flex-1 min-h-14 items-center justify-center gap-2 rounded-xl bg-goal px-6 text-on-dark transition-colors active:bg-goal-active disabled:bg-goal-disabled disabled:text-on-dark/70"
+            >
+              <span
+                data-testid="insider-start-game-cta-label"
+                className="font-display text-[20px] uppercase tracking-[1px]"
+              >
+                {startCtaCopy}
+              </span>
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={!canStart || isPending}
+            aria-busy={isPending}
+            data-testid="insider-start-game-cta"
+            className="flex min-h-14 w-full items-center justify-center gap-2 rounded-xl bg-goal px-6 text-on-dark transition-colors active:bg-goal-active disabled:bg-goal-disabled disabled:text-on-dark/70"
           >
-            {startCtaCopy}
-          </span>
-        </button>
+            <span
+              data-testid="insider-start-game-cta-label"
+              className="font-display text-[20px] uppercase tracking-[1px]"
+            >
+              {startCtaCopy}
+            </span>
+          </button>
+        )}
       </section>
     </main>
+  )
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Issue #24 — between-rounds pack control. Host gets editable PackChips
+// wired to change_insider_pack RPC; non-host gets a read-only `Pack: <name>`
+// label that updates via the realtime room-config subscription.
+// ───────────────────────────────────────────────────────────────────────────
+
+function BetweenRoundsPackControl({
+  roomId,
+  mePlayerId,
+  isHost,
+  packs,
+}: {
+  roomId: string
+  mePlayerId: string
+  isHost: boolean
+  packs: EnabledPack[]
+}) {
+  const [packSlug, setPackSlug] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [pendingSlug, setPendingSlug] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  // Initial fetch + realtime sync. game_insider_room_config is `-- no-realtime`
+  // so we re-poll on the rooms.current_round flip (which always accompanies
+  // start_insider_round). Polling on the rooms-table change keeps non-host
+  // clients honest without adding a second realtime channel for the config.
+  useEffect(() => {
+    let active = true
+    void (async () => {
+      const { data } = await supabase
+        .from("game_insider_room_config")
+        .select("pack_slug")
+        .eq("room_id", roomId)
+        .maybeSingle()
+      if (!active) return
+      if (data?.pack_slug) setPackSlug(data.pack_slug as string)
+    })()
+    return () => {
+      active = false
+    }
+  }, [roomId])
+
+  // Listen for any pack changes (host action only). When the host writes via
+  // change_insider_pack the rooms row doesn't change, so a realtime ping on
+  // game_insider_room_config isn't available; instead we poll on a short
+  // postgres_changes subscription against rooms (host actions almost always
+  // touch rooms shortly after, e.g. start_insider_round) plus an interval
+  // fallback for the non-host case while the chip is selected. To keep this
+  // simple and correct: subscribe to rooms changes and re-fetch the config.
+  useEffect(() => {
+    const channel = supabase
+      .channel(`insider-room-config-${roomId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "rooms",
+          filter: `id=eq.${roomId}`,
+        },
+        async () => {
+          const { data } = await supabase
+            .from("game_insider_room_config")
+            .select("pack_slug")
+            .eq("room_id", roomId)
+            .maybeSingle()
+          if (data?.pack_slug) setPackSlug(data.pack_slug as string)
+        },
+      )
+      .subscribe()
+    return () => {
+      void supabase.removeChannel(channel)
+    }
+  }, [roomId])
+
+  const packIndexBySlug = useMemo(() => {
+    const map = new Map<string, number>()
+    packs.forEach((pack, idx) => {
+      map.set(pack.slug, idx)
+    })
+    return map
+  }, [packs])
+
+  const currentPack = useMemo(
+    () => (packSlug ? packs.find((p) => p.slug === packSlug) ?? null : null),
+    [packs, packSlug],
+  )
+
+  function handlePick(nextSlug: string) {
+    if (nextSlug === packSlug) return
+    setError(null)
+    setPendingSlug(nextSlug)
+    // Optimistic flip: update local state immediately so the chip feels
+    // responsive. On error we roll back via the catch.
+    const previousSlug = packSlug
+    setPackSlug(nextSlug)
+    startTransition(async () => {
+      const result = await changeInsiderPackAction({
+        roomId,
+        playerId: mePlayerId,
+        packSlug: nextSlug,
+      })
+      if (!result.ok) {
+        setError(result.error)
+        setPackSlug(previousSlug)
+      }
+      setPendingSlug(null)
+    })
+  }
+
+  if (!isHost) {
+    return (
+      <section
+        data-testid="insider-pack-readonly"
+        className="flex items-center justify-between gap-3 rounded-xl border border-hairline bg-surface-elevated px-4 py-3"
+      >
+        <span className="font-display text-[12px] uppercase tracking-[2px] text-on-dark-soft">
+          Pack
+        </span>
+        <span
+          data-testid="insider-pack-readonly-name"
+          className="font-display text-[16px] uppercase tracking-[0.5px] text-on-dark"
+        >
+          {currentPack?.displayNameTh ?? currentPack?.displayName ?? "—"}
+        </span>
+      </section>
+    )
+  }
+
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="font-display text-xs uppercase tracking-[2px] text-on-dark-soft">
+        ── คลังคำ / WORD PACK ──
+      </h2>
+      <div
+        role="radiogroup"
+        aria-label="Word pack"
+        className="grid grid-cols-2 gap-3"
+      >
+        {packs.map((pack) => {
+          const isSelected = packSlug === pack.slug
+          const tagIdx = packIndexBySlug.get(pack.slug) ?? 0
+          const showSubLabel = Boolean(
+            pack.displayNameTh && pack.displayName !== pack.displayNameTh,
+          )
+          return (
+            <PackChip
+              key={pack.slug}
+              joinIndex={tagIdx}
+              label={pack.displayNameTh ?? pack.displayName}
+              subLabel={showSubLabel ? pack.displayName : undefined}
+              selected={isSelected}
+              disabled={isPending && pendingSlug !== pack.slug}
+              onTap={() => handlePick(pack.slug)}
+              testId={`pack-chip-${pack.slug}`}
+            />
+          )
+        })}
+      </div>
+      {error ? (
+        <p
+          role="alert"
+          data-testid="insider-pack-error"
+          className="rounded-lg border border-error/40 bg-error/10 px-4 py-2 text-center text-sm font-medium text-error"
+        >
+          {error}
+        </p>
+      ) : null}
+    </section>
+  )
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Issue #24 — RESET GAME button (between-rounds host only). Opens a custom
+// Stadium-Energy `<dialog>` confirm; on confirm calls reset_insider_game RPC.
+// Native confirm() is rejected per the rubric's q1-round-1 clarification.
+// ───────────────────────────────────────────────────────────────────────────
+
+function ResetGameButton({
+  roomId,
+  mePlayerId,
+  disabled,
+}: {
+  roomId: string
+  mePlayerId: string
+  disabled: boolean
+}) {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function openDialog() {
+    setError(null)
+    dialogRef.current?.showModal()
+  }
+
+  function closeDialog() {
+    dialogRef.current?.close()
+  }
+
+  function handleConfirm() {
+    setError(null)
+    startTransition(async () => {
+      const result = await resetInsiderGameAction({
+        roomId,
+        playerId: mePlayerId,
+      })
+      if (!result.ok) {
+        setError(result.error)
+        return
+      }
+      closeDialog()
+      // Realtime subscription on rooms in Lobby flips status + current_round;
+      // the lobby re-routes to the initial-lobby variant automatically.
+    })
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openDialog}
+        disabled={disabled || isPending}
+        data-testid="insider-reset-game-cta"
+        className="flex min-h-14 items-center justify-center rounded-xl border border-hairline bg-surface-elevated px-4 font-display text-[14px] uppercase tracking-[1px] text-on-dark transition-colors active:bg-surface disabled:opacity-60"
+      >
+        Reset
+      </button>
+      <dialog
+        ref={dialogRef}
+        data-testid="insider-reset-confirm-dialog"
+        className="m-auto w-[min(92vw,400px)] rounded-2xl border border-hairline bg-ink p-6 text-on-dark backdrop:bg-black/60"
+      >
+        <div className="flex flex-col gap-4">
+          <h2 className="font-display text-[24px] uppercase leading-none tracking-[1px] text-on-dark">
+            RESET GAME?
+          </h2>
+          <p className="font-body text-[14px] text-on-dark-soft">
+            ลบคะแนนและรอบที่เล่นไปแล้วทั้งหมด ผู้เล่น คลังคำ และจำนวนรอบ
+            ยังคงอยู่
+          </p>
+          {error ? (
+            <p
+              role="alert"
+              data-testid="insider-reset-error"
+              className="rounded-lg border border-error/40 bg-error/10 px-3 py-2 text-sm font-medium text-error"
+            >
+              {error}
+            </p>
+          ) : null}
+          <div className="flex items-stretch gap-2">
+            <button
+              type="button"
+              onClick={closeDialog}
+              disabled={isPending}
+              data-testid="insider-reset-cancel-cta"
+              className="flex flex-1 min-h-12 items-center justify-center rounded-xl border border-hairline bg-surface-elevated px-4 font-display text-[14px] uppercase tracking-[1px] text-on-dark active:bg-surface disabled:opacity-60"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleConfirm}
+              disabled={isPending}
+              aria-busy={isPending}
+              data-testid="insider-reset-confirm-cta"
+              className="flex flex-1 min-h-12 items-center justify-center rounded-xl bg-error px-4 font-display text-[14px] uppercase tracking-[1px] text-on-dark active:opacity-90 disabled:opacity-60"
+            >
+              {isPending ? "กำลังรีเซ็ต..." : "Reset"}
+            </button>
+          </div>
+        </div>
+      </dialog>
+    </>
   )
 }

--- a/apps/insider/app/room/[code]/page.tsx
+++ b/apps/insider/app/room/[code]/page.tsx
@@ -1,3 +1,5 @@
+import { listEnabledPacks } from "@social-hub/content"
+import { createSupabaseServerClient } from "@/lib/supabase-server"
 import { Lobby } from "./lobby"
 
 export const dynamic = "force-dynamic"
@@ -9,5 +11,7 @@ export default async function InsiderRoomPage({
 }) {
   const { code: rawCode } = await params
   const code = rawCode.toUpperCase()
-  return <Lobby code={code} />
+  const supabase = createSupabaseServerClient()
+  const packs = await listEnabledPacks(supabase)
+  return <Lobby code={code} packs={packs} />
 }

--- a/apps/insider/e2e/_helpers/setup.ts
+++ b/apps/insider/e2e/_helpers/setup.ts
@@ -1,0 +1,153 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+import type { Page } from "@playwright/test"
+
+// E2E fixture helpers (issue #24). The mid-game / end-of-game UI variants
+// require state that takes 5+ minutes to reach via real gameplay (multiple
+// rounds, voting, reveal). Instead we seed the DB directly via the admin
+// (service_role) Supabase client and then navigate the page after stamping
+// localStorage with the right player_id. This keeps the specs focused on UI
+// surface, which is what the rubric asks for.
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL ?? "http://127.0.0.1:54321"
+
+const LOCAL_SERVICE_ROLE_FALLBACK =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+  "eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0." +
+  "EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU"
+
+const SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ?? LOCAL_SERVICE_ROLE_FALLBACK
+
+export const PACK_DEFAULT = "football-premier-league"
+export const PACK_ALT = "football-la-liga"
+
+export interface RoomFixture {
+  roomId: string
+  code: string
+  hostId: string
+  insiderId: string
+  playerAId: string
+  playerBId: string
+}
+
+export interface SeedRoomArgs {
+  code: string
+  status: "LOBBY" | "PLAYING"
+  currentRound: number
+  maxRounds?: number
+  packSlug?: string
+  // Latest round phase. If set, also inserts game_insider_round +
+  // (optionally) roles/votes for end-of-game scenarios.
+  roundPhase?:
+    | "preparing"
+    | "asking"
+    | "guessed"
+    | "voting"
+    | "reveal"
+    | "result_failed"
+  // If true, also seed roles + votes so the reveal-derived view (caught/
+  // escaped) is meaningful.
+  withRolesAndVotes?: boolean
+  // Initial total_score values to verify reset zeroing.
+  scores?: { host: number; insider: number; a: number; b: number }
+}
+
+export function adminClient(): SupabaseClient {
+  return createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  })
+}
+
+export async function cleanupRoomByCode(code: string): Promise<void> {
+  const admin = adminClient()
+  await admin.from("rooms").delete().eq("code", code)
+}
+
+export async function seedRoom(args: SeedRoomArgs): Promise<RoomFixture> {
+  const admin = adminClient()
+  const hostId = crypto.randomUUID()
+  const insiderId = crypto.randomUUID()
+  const playerAId = crypto.randomUUID()
+  const playerBId = crypto.randomUUID()
+  const scores = args.scores ?? { host: 5, insider: 3, a: 8, b: 4 }
+  const maxRounds = args.maxRounds ?? 3
+
+  await cleanupRoomByCode(args.code)
+
+  const { data: room, error: roomErr } = await admin
+    .from("rooms")
+    .insert({
+      code: args.code,
+      max_rounds: maxRounds,
+      score_positions: 1,
+      category: "premier-league",
+      game_type: "insider",
+      host_player_id: hostId,
+      status: args.status,
+      current_round: args.currentRound,
+    })
+    .select("id")
+    .single()
+  if (roomErr || !room) throw roomErr ?? new Error("seedRoom: insert failed")
+
+  const { error: pErr } = await admin.from("players").insert([
+    { room_id: room.id, player_id: hostId, display_name: "Host", join_order: 1, connected: true, total_score: scores.host },
+    { room_id: room.id, player_id: insiderId, display_name: "Insider", join_order: 2, connected: true, total_score: scores.insider },
+    { room_id: room.id, player_id: playerAId, display_name: "Alice", join_order: 3, connected: true, total_score: scores.a },
+    { room_id: room.id, player_id: playerBId, display_name: "Bob", join_order: 4, connected: true, total_score: scores.b },
+  ])
+  if (pErr) throw pErr
+
+  const { error: cfgErr } = await admin
+    .from("game_insider_room_config")
+    .insert({
+      room_id: room.id,
+      pack_slug: args.packSlug ?? PACK_DEFAULT,
+      time_limit_s: 300,
+      round_count: maxRounds,
+    })
+  if (cfgErr) throw cfgErr
+
+  if (args.roundPhase && args.currentRound) {
+    const { error: rErr } = await admin.from("game_insider_round").insert({
+      room_id: room.id,
+      round_number: args.currentRound,
+      pack_slug: args.packSlug ?? PACK_DEFAULT,
+      secret_value: "FERNANDO TORRES",
+      time_limit_s: 300,
+      phase: args.roundPhase,
+      started_at: new Date().toISOString(),
+      vote_deadline: new Date(Date.now() + 60 * 1000).toISOString(),
+      eligible_voter_ids: [hostId, insiderId, playerAId, playerBId],
+    })
+    if (rErr) throw rErr
+
+    if (args.withRolesAndVotes) {
+      const { error: rolesErr } = await admin.from("game_insider_roles").insert([
+        { room_id: room.id, round_number: args.currentRound, player_id: hostId, role: "master" },
+        { room_id: room.id, round_number: args.currentRound, player_id: insiderId, role: "insider" },
+        { room_id: room.id, round_number: args.currentRound, player_id: playerAId, role: "player" },
+        { room_id: room.id, round_number: args.currentRound, player_id: playerBId, role: "player" },
+      ])
+      if (rolesErr) throw rolesErr
+
+      const { error: vErr } = await admin.from("game_insider_votes").insert([
+        { room_id: room.id, round_number: args.currentRound, voter_player_id: hostId, voted_player_id: insiderId },
+        { room_id: room.id, round_number: args.currentRound, voter_player_id: playerAId, voted_player_id: insiderId },
+      ])
+      if (vErr) throw vErr
+    }
+  }
+
+  return { roomId: room.id, code: args.code, hostId, insiderId, playerAId, playerBId }
+}
+
+// Set localStorage player_id BEFORE the lobby's first React render. The lobby
+// reads readPlayerId() from `insider_player_id` (storage-key convention is
+// `${namespace}_player_id` — see packages/core/src/player-id.ts).
+export async function asPlayer(page: Page, playerId: string): Promise<void> {
+  await page.addInitScript((pid: string) => {
+    window.localStorage.setItem("insider_player_id", pid)
+  }, playerId)
+}

--- a/apps/insider/e2e/between-rounds-lobby.spec.ts
+++ b/apps/insider/e2e/between-rounds-lobby.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "@playwright/test"
+import {
+  PACK_ALT,
+  PACK_DEFAULT,
+  adminClient,
+  asPlayer,
+  cleanupRoomByCode,
+  seedRoom,
+} from "./_helpers/setup"
+
+// Issue #24 — between-rounds lobby variant.
+// Rubric coverage: Acceptance #1 (host editable pack chips updating
+// game_insider_room_config.pack_slug via change_insider_pack RPC) and
+// Acceptance #3 (non-host sees read-only `Pack: <name>` label).
+
+const HOST_CODE = "INS24A"
+const NONHOST_CODE = "INS24B"
+
+test.describe("Insider between-rounds lobby (issue #24)", () => {
+  test.afterEach(async () => {
+    await cleanupRoomByCode(HOST_CODE)
+    await cleanupRoomByCode(NONHOST_CODE)
+  })
+
+  test("host between rounds sees pack chips and can switch pack via RPC", async ({
+    page,
+  }) => {
+    const f = await seedRoom({
+      code: HOST_CODE,
+      status: "LOBBY",
+      currentRound: 1,
+      maxRounds: 5,
+      packSlug: PACK_DEFAULT,
+      roundPhase: "reveal",
+      withRolesAndVotes: true,
+    })
+
+    await asPlayer(page, f.hostId)
+    await page.goto(`/room/${HOST_CODE}`)
+
+    await expect(page.getByTestId(`pack-chip-${PACK_DEFAULT}`)).toBeVisible({
+      timeout: 15_000,
+    })
+    await expect(page.getByTestId(`pack-chip-${PACK_ALT}`)).toBeVisible()
+    await expect(page.getByTestId("insider-reset-game-cta")).toBeVisible()
+
+    // Tap the alternate pack — UI is optimistic, RPC fires under the hood.
+    await page.getByTestId(`pack-chip-${PACK_ALT}`).click()
+
+    // Verify the DB row was updated by change_insider_pack.
+    const admin = adminClient()
+    await expect
+      .poll(
+        async () => {
+          const { data } = await admin
+            .from("game_insider_room_config")
+            .select("pack_slug")
+            .eq("room_id", f.roomId)
+            .single()
+          return data?.pack_slug
+        },
+        { timeout: 10_000 },
+      )
+      .toBe(PACK_ALT)
+  })
+
+  test("non-host between rounds sees read-only Pack label and no destructive controls", async ({
+    page,
+  }) => {
+    const f = await seedRoom({
+      code: NONHOST_CODE,
+      status: "LOBBY",
+      currentRound: 1,
+      maxRounds: 5,
+      packSlug: PACK_DEFAULT,
+      roundPhase: "reveal",
+      withRolesAndVotes: true,
+    })
+
+    await asPlayer(page, f.playerAId)
+    await page.goto(`/room/${NONHOST_CODE}`)
+
+    await expect(page.getByTestId("insider-pack-readonly")).toBeVisible({
+      timeout: 15_000,
+    })
+    await expect(page.getByTestId("insider-pack-readonly-name")).not.toBeEmpty()
+    await expect(page.getByTestId(`pack-chip-${PACK_DEFAULT}`)).toHaveCount(0)
+    await expect(page.getByTestId("insider-reset-game-cta")).toHaveCount(0)
+  })
+})

--- a/apps/insider/e2e/game-end-final-scoreboard.spec.ts
+++ b/apps/insider/e2e/game-end-final-scoreboard.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test } from "@playwright/test"
+import {
+  adminClient,
+  asPlayer,
+  cleanupRoomByCode,
+  seedRoom,
+} from "./_helpers/setup"
+
+// Issue #24 — game-end FinalScoreboard.
+// Rubric coverage: Acceptance #4 (FinalScoreboard renders when
+// current_round >= max_rounds, GAME OVER header, leaderboard sorted desc,
+// 1st place highlighted) + Acceptance #5 (PLAY AGAIN) + Acceptance #6
+// (BACK TO LOBBY).
+
+const FINAL_CODE = "INS24C"
+const PLAY_AGAIN_CODE = "INS24D"
+const BACK_TO_LOBBY_CODE = "INS24E"
+
+test.describe("Insider FinalScoreboard (issue #24)", () => {
+  test.afterEach(async () => {
+    for (const code of [FINAL_CODE, PLAY_AGAIN_CODE, BACK_TO_LOBBY_CODE]) {
+      await cleanupRoomByCode(code)
+    }
+  })
+
+  test("renders GAME OVER + leaderboard sorted desc with 1st place highlighted", async ({
+    page,
+  }) => {
+    const f = await seedRoom({
+      code: FINAL_CODE,
+      status: "PLAYING",
+      currentRound: 3,
+      maxRounds: 3,
+      roundPhase: "reveal",
+      withRolesAndVotes: true,
+      // Alice highest, then Host, then Bob, then Insider.
+      scores: { host: 4, insider: 1, a: 8, b: 2 },
+    })
+
+    await asPlayer(page, f.hostId)
+    await page.goto(`/room/${FINAL_CODE}`)
+
+    await expect(page.getByTestId("insider-final-header")).toHaveText(
+      "GAME OVER",
+      { timeout: 15_000 },
+    )
+
+    await expect(page.getByTestId("insider-final-winner-name")).toHaveText(
+      "ALICE",
+    )
+    await expect(page.getByTestId("insider-final-winner-score")).toContainText(
+      "8 pts",
+    )
+
+    // Rank order: Alice (8) → Host (4) → Bob (2) → Insider (1).
+    const rows = page.getByTestId(/insider-final-row-/)
+    await expect(rows).toHaveCount(4)
+    await expect(rows.nth(0)).toHaveAttribute("data-rank", "1")
+    await expect(rows.nth(1)).toHaveAttribute("data-rank", "2")
+    await expect(rows.nth(2)).toHaveAttribute("data-rank", "3")
+    await expect(rows.nth(3)).toHaveAttribute("data-rank", "4")
+  })
+
+  test("PLAY AGAIN resets scores and starts round 1 (room is then PLAYING+round=1)", async ({
+    page,
+  }) => {
+    const f = await seedRoom({
+      code: PLAY_AGAIN_CODE,
+      status: "PLAYING",
+      currentRound: 3,
+      maxRounds: 3,
+      roundPhase: "reveal",
+      withRolesAndVotes: true,
+      scores: { host: 4, insider: 1, a: 8, b: 2 },
+    })
+
+    await asPlayer(page, f.hostId)
+    await page.goto(`/room/${PLAY_AGAIN_CODE}`)
+
+    await expect(page.getByTestId("insider-final-play-again-cta")).toBeVisible({
+      timeout: 15_000,
+    })
+    await page.getByTestId("insider-final-play-again-cta").click()
+
+    const admin = adminClient()
+    await expect
+      .poll(
+        async () => {
+          const { data } = await admin
+            .from("rooms")
+            .select("status, current_round")
+            .eq("id", f.roomId)
+            .single()
+          return data
+        },
+        { timeout: 15_000 },
+      )
+      .toMatchObject({ status: "PLAYING", current_round: 1 })
+
+    // Scores zeroed.
+    const { data: scores } = await admin
+      .from("players")
+      .select("total_score")
+      .eq("room_id", f.roomId)
+    expect(scores?.every((s) => s.total_score === 0)).toBe(true)
+  })
+
+  test("BACK TO LOBBY resets and lands on initial empty lobby (LOBBY+round=0)", async ({
+    page,
+  }) => {
+    const f = await seedRoom({
+      code: BACK_TO_LOBBY_CODE,
+      status: "PLAYING",
+      currentRound: 3,
+      maxRounds: 3,
+      roundPhase: "reveal",
+      withRolesAndVotes: true,
+      scores: { host: 4, insider: 1, a: 8, b: 2 },
+    })
+
+    await asPlayer(page, f.hostId)
+    await page.goto(`/room/${BACK_TO_LOBBY_CODE}`)
+
+    await expect(
+      page.getByTestId("insider-final-back-to-lobby-cta"),
+    ).toBeVisible({ timeout: 15_000 })
+    await page.getByTestId("insider-final-back-to-lobby-cta").click()
+
+    const admin = adminClient()
+    await expect
+      .poll(
+        async () => {
+          const { data } = await admin
+            .from("rooms")
+            .select("status, current_round")
+            .eq("id", f.roomId)
+            .single()
+          return data
+        },
+        { timeout: 15_000 },
+      )
+      .toMatchObject({ status: "LOBBY", current_round: 0 })
+  })
+})

--- a/apps/insider/e2e/mid-game-reset.spec.ts
+++ b/apps/insider/e2e/mid-game-reset.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "@playwright/test"
+import {
+  PACK_DEFAULT,
+  adminClient,
+  asPlayer,
+  cleanupRoomByCode,
+  seedRoom,
+} from "./_helpers/setup"
+
+// Issue #24 — host hits RESET between rounds.
+// Rubric coverage: Acceptance #2 (RESET GAME with confirm dialog wipes
+// per-round tables + zeroes total_score; preserves players, code, host,
+// pack, timer, round_count). Also covers the State #2 "loading state" hint
+// (the confirm CTA disables itself while the RPC is in flight).
+
+const CODE = "INS24F"
+
+test.describe("Insider mid-game RESET (issue #24)", () => {
+  test.afterEach(async () => {
+    await cleanupRoomByCode(CODE)
+  })
+
+  test("host RESET wipes per-round state and zeroes scores; preserves players + config", async ({
+    page,
+  }) => {
+    const f = await seedRoom({
+      code: CODE,
+      status: "LOBBY",
+      currentRound: 2,
+      maxRounds: 5,
+      packSlug: PACK_DEFAULT,
+      roundPhase: "reveal",
+      withRolesAndVotes: true,
+      scores: { host: 6, insider: 3, a: 5, b: 4 },
+    })
+
+    await asPlayer(page, f.hostId)
+    await page.goto(`/room/${CODE}`)
+
+    // RESET button visible (host between rounds).
+    const reset = page.getByTestId("insider-reset-game-cta")
+    await expect(reset).toBeVisible({ timeout: 15_000 })
+
+    // Tap → custom <dialog> confirm appears (NOT native confirm).
+    await reset.click()
+    await expect(
+      page.getByTestId("insider-reset-confirm-dialog"),
+    ).toBeVisible()
+
+    // Confirm.
+    await page.getByTestId("insider-reset-confirm-cta").click()
+
+    const admin = adminClient()
+
+    // Room shell reset: status=LOBBY, current_round=0.
+    await expect
+      .poll(
+        async () => {
+          const { data } = await admin
+            .from("rooms")
+            .select("status, current_round, code, host_player_id, max_rounds")
+            .eq("id", f.roomId)
+            .single()
+          return data
+        },
+        { timeout: 15_000 },
+      )
+      .toMatchObject({
+        status: "LOBBY",
+        current_round: 0,
+        code: CODE,
+        host_player_id: f.hostId,
+        max_rounds: 5,
+      })
+
+    // Scores zeroed.
+    const { data: scores } = await admin
+      .from("players")
+      .select("display_name, total_score")
+      .eq("room_id", f.roomId)
+      .order("join_order", { ascending: true })
+    expect(scores).toHaveLength(4)
+    expect(scores?.every((s) => s.total_score === 0)).toBe(true)
+    expect(scores?.map((s) => s.display_name)).toEqual([
+      "Host",
+      "Insider",
+      "Alice",
+      "Bob",
+    ])
+
+    // Per-round tables wiped.
+    for (const t of [
+      "game_insider_round",
+      "game_insider_roles",
+      "game_insider_votes",
+      "game_insider_responses",
+    ]) {
+      const { count } = await admin
+        .from(t)
+        .select("*", { count: "exact", head: true })
+        .eq("room_id", f.roomId)
+      expect(count ?? 0).toBe(0)
+    }
+
+    // Config preserved.
+    const { data: cfg } = await admin
+      .from("game_insider_room_config")
+      .select("pack_slug, time_limit_s, round_count")
+      .eq("room_id", f.roomId)
+      .single()
+    expect(cfg).toMatchObject({
+      pack_slug: PACK_DEFAULT,
+      time_limit_s: 300,
+      round_count: 5,
+    })
+  })
+})

--- a/apps/insider/lib/__tests__/final-scoreboard.test.tsx
+++ b/apps/insider/lib/__tests__/final-scoreboard.test.tsx
@@ -1,0 +1,191 @@
+/// <reference types="@testing-library/jest-dom" />
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+
+// vi.mock factories are hoisted to the top of the file. To share state with
+// the mocks, we use vi.hoisted so the helpers also run pre-import.
+const mocks = vi.hoisted(() => {
+  const fakePlayers = [
+    { id: "p1", player_id: "host", display_name: "Host", join_order: 1, total_score: 7 },
+    { id: "p2", player_id: "alice", display_name: "Alice", join_order: 2, total_score: 12 },
+    { id: "p3", player_id: "bob", display_name: "Bob", join_order: 3, total_score: 4 },
+  ]
+  const supabaseMock = {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          order: vi.fn(async () => ({ data: fakePlayers, error: null })),
+        })),
+      })),
+    })),
+    channel: vi.fn(() => ({
+      on: vi.fn().mockReturnThis(),
+      subscribe: vi.fn().mockReturnValue({}),
+    })),
+    removeChannel: vi.fn(),
+  }
+  const advanceToRevealMock = vi.fn(async (..._args: unknown[]) => undefined)
+  const startActionMock = vi.fn(async (_input: unknown) => ({
+    ok: true as const,
+    roundNumber: 1,
+  }))
+  const resetActionMock = vi.fn(async (_input: unknown) => ({ ok: true as const }))
+  return {
+    supabaseMock,
+    advanceToRevealMock,
+    startActionMock,
+    resetActionMock,
+  }
+})
+
+vi.mock("@/lib/supabase", () => ({ supabase: mocks.supabaseMock }))
+vi.mock("@/lib/insider-rpc", () => ({
+  advanceToReveal: mocks.advanceToRevealMock,
+}))
+vi.mock("@/app/actions/start-insider-round", () => ({
+  startInsiderRoundAction: mocks.startActionMock,
+}))
+vi.mock("@/app/actions/reset-insider-game", () => ({
+  resetInsiderGameAction: mocks.resetActionMock,
+}))
+
+import { FinalScoreboard } from "@/app/room/[code]/final-scoreboard"
+
+beforeEach(() => {
+  mocks.advanceToRevealMock.mockClear()
+  mocks.startActionMock.mockClear()
+  mocks.resetActionMock.mockClear()
+  mocks.supabaseMock.from.mockClear()
+  mocks.supabaseMock.channel.mockClear()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("FinalScoreboard (issue #24)", () => {
+  it("renders GAME OVER header + leaderboard sorted desc by total_score", async () => {
+    render(
+      <FinalScoreboard
+        roomId="room-1"
+        round={5}
+        mePlayerId="host"
+        isHost
+        phase="reveal"
+      />,
+    )
+
+    expect(screen.getByTestId("insider-final-header")).toHaveTextContent(
+      "GAME OVER",
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("insider-final-winner-name")).toHaveTextContent(
+        "ALICE",
+      )
+    })
+
+    expect(screen.getByTestId("insider-final-winner-score")).toHaveTextContent(
+      "12 pts",
+    )
+
+    const rows = screen.getAllByTestId(/insider-final-row-/)
+    expect(rows).toHaveLength(3)
+    expect(rows[0]).toHaveAttribute("data-rank", "1")
+    expect(rows[0].dataset.testid).toBe("insider-final-row-alice")
+    expect(rows[1]).toHaveAttribute("data-rank", "2")
+    expect(rows[1].dataset.testid).toBe("insider-final-row-host")
+    expect(rows[2]).toHaveAttribute("data-rank", "3")
+    expect(rows[2].dataset.testid).toBe("insider-final-row-bob")
+  })
+
+  it("fires advance_to_reveal on mount (idempotent scoring seal)", async () => {
+    render(
+      <FinalScoreboard
+        roomId="room-2"
+        round={5}
+        mePlayerId="host"
+        isHost
+        phase="reveal"
+      />,
+    )
+
+    await waitFor(() => {
+      expect(mocks.advanceToRevealMock).toHaveBeenCalledWith(mocks.supabaseMock, {
+        roomId: "room-2",
+        round: 5,
+      })
+    })
+  })
+
+  it("PLAY AGAIN CTA is host-only — non-host sees disabled state with rest copy", async () => {
+    render(
+      <FinalScoreboard
+        roomId="room-3"
+        round={5}
+        mePlayerId="alice"
+        isHost={false}
+        phase="reveal"
+      />,
+    )
+
+    const cta = await screen.findByTestId("insider-final-play-again-cta")
+    expect(cta).toBeDisabled()
+    expect(cta).toHaveTextContent("รอโฮสต์เริ่มเกมใหม่")
+
+    const back = screen.getByTestId("insider-final-back-to-lobby-cta")
+    expect(back).toBeDisabled()
+  })
+
+  it("BACK TO LOBBY calls resetInsiderGameAction (no startInsiderRound)", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup()
+    render(
+      <FinalScoreboard
+        roomId="room-4"
+        round={5}
+        mePlayerId="host"
+        isHost
+        phase="reveal"
+      />,
+    )
+
+    const cta = await screen.findByTestId("insider-final-back-to-lobby-cta")
+    await user.click(cta)
+
+    await waitFor(() => {
+      expect(mocks.resetActionMock).toHaveBeenCalledWith({
+        roomId: "room-4",
+        playerId: "host",
+      })
+    })
+    expect(mocks.startActionMock).not.toHaveBeenCalled()
+  })
+
+  it("PLAY AGAIN calls reset then startInsiderRound", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup()
+    render(
+      <FinalScoreboard
+        roomId="room-5"
+        round={5}
+        mePlayerId="host"
+        isHost
+        phase="reveal"
+      />,
+    )
+
+    const cta = await screen.findByTestId("insider-final-play-again-cta")
+    await user.click(cta)
+
+    await waitFor(() => {
+      expect(mocks.resetActionMock).toHaveBeenCalledWith({
+        roomId: "room-5",
+        playerId: "host",
+      })
+      expect(mocks.startActionMock).toHaveBeenCalledWith({
+        roomId: "room-5",
+        playerId: "host",
+      })
+    })
+  })
+})

--- a/apps/insider/lib/__tests__/lobby-between-rounds.test.tsx
+++ b/apps/insider/lib/__tests__/lobby-between-rounds.test.tsx
@@ -1,0 +1,254 @@
+/// <reference types="@testing-library/jest-dom" />
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+
+// Mocks for the dependencies the Lobby reaches into. We're focused on the
+// between-rounds UI variants — pack chips visible to host, read-only label
+// visible to non-host, dialog gating on RESET GAME — not on the realtime
+// plumbing or the asking/voting/reveal sub-screens (those have their own
+// tests + are exercised by Playwright in apps/insider/e2e).
+
+const HOST_ID = "00000000-0000-4000-8000-000000000001"
+const OTHER_ID = "00000000-0000-4000-8000-000000000002"
+
+const state = vi.hoisted(() => {
+  const HOST = "00000000-0000-4000-8000-000000000001"
+  return {
+    mockRoom: {
+      id: "00000000-0000-4000-8000-000000000010",
+      code: "INS24Z",
+      status: "LOBBY",
+      host_player_id: HOST,
+      current_round: 1 as number,
+      max_rounds: 5,
+    },
+    mockPlayers: [] as Array<{
+      id: string
+      player_id: string
+      display_name: string
+      join_order: number
+    }>,
+    mockMePlayerId: HOST,
+    mockPackSlug: "football-premier-league",
+  }
+})
+
+const supabaseMock = vi.hoisted(() => ({
+  from: vi.fn(),
+  channel: vi.fn(),
+  removeChannel: vi.fn(),
+}))
+
+// Wire the table-aware behavior after the hoisted blocks (vi.fn was constructed
+// above; we just configure its implementation here).
+supabaseMock.from.mockImplementation((table: string) => {
+  if (table === "rooms") {
+    return {
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({ data: state.mockRoom, error: null }),
+        }),
+      }),
+    }
+  }
+  if (table === "players") {
+    return {
+      select: () => ({
+        eq: () => ({
+          order: async () => ({ data: state.mockPlayers, error: null }),
+        }),
+      }),
+    }
+  }
+  if (table === "game_insider_round") {
+    return {
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({
+              data: { phase: "reveal" },
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    }
+  }
+  if (table === "game_insider_room_config") {
+    return {
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({
+            data: { pack_slug: state.mockPackSlug },
+            error: null,
+          }),
+        }),
+      }),
+    }
+  }
+  return {
+    select: () => ({
+      eq: () => ({
+        maybeSingle: async () => ({ data: null, error: null }),
+      }),
+    }),
+  }
+})
+supabaseMock.channel.mockImplementation(() => ({
+  on: vi.fn().mockReturnThis(),
+  subscribe: vi.fn().mockReturnValue({}),
+}))
+
+vi.mock("@/lib/supabase", () => ({ supabase: supabaseMock }))
+vi.mock("@/lib/player-id", () => ({
+  readPlayerId: () => state.mockMePlayerId,
+  getOrCreatePlayerId: () => state.mockMePlayerId,
+}))
+vi.mock("@social-hub/core", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("@social-hub/core")
+  return {
+    ...actual,
+    useRoomRealtime: () => undefined,
+  }
+})
+vi.mock("@/app/actions/start-insider-round", () => ({
+  startInsiderRoundAction: vi.fn(async () => ({ ok: true, roundNumber: 1 })),
+}))
+vi.mock("@/app/actions/reset-insider-game", () => ({
+  resetInsiderGameAction: vi.fn(async () => ({ ok: true })),
+}))
+vi.mock("@/app/actions/change-insider-pack", () => ({
+  changeInsiderPackAction: vi.fn(async () => ({ ok: true })),
+}))
+vi.mock("@/app/actions/join-insider-room", () => ({
+  joinInsiderRoomAction: vi.fn(async () => ({ ok: true, playerId: HOST_ID })),
+}))
+
+// stub UI bits we don't care about — minimize render footprint.
+vi.mock("@social-hub/ui", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("@social-hub/ui")
+  return actual
+})
+
+import { Lobby } from "@/app/room/[code]/lobby"
+
+const PACKS = [
+  {
+    slug: "football-premier-league",
+    displayName: "Premier League",
+    displayNameTh: "พรีเมียร์ลีก",
+    handler: "football_category",
+  },
+  {
+    slug: "football-la-liga",
+    displayName: "La Liga",
+    displayNameTh: "ลาลีกา",
+    handler: "football_category",
+  },
+]
+
+beforeEach(() => {
+  state.mockRoom = {
+    id: "00000000-0000-4000-8000-000000000010",
+    code: "INS24Z",
+    status: "LOBBY",
+    host_player_id: HOST_ID,
+    current_round: 1,
+    max_rounds: 5,
+  }
+  state.mockPlayers = [
+    { id: "p1", player_id: HOST_ID, display_name: "Host", join_order: 1 },
+    { id: "p2", player_id: OTHER_ID, display_name: "Other", join_order: 2 },
+    { id: "p3", player_id: "0000-x-3", display_name: "Three", join_order: 3 },
+  ]
+  state.mockMePlayerId = HOST_ID
+  state.mockPackSlug = "football-premier-league"
+
+  // jsdom does not implement HTMLDialogElement.showModal/close — polyfill so
+  // the RESET GAME confirm flow doesn't throw on click.
+  if (
+    typeof HTMLDialogElement !== "undefined" &&
+    typeof HTMLDialogElement.prototype.showModal !== "function"
+  ) {
+    HTMLDialogElement.prototype.showModal = function showModal() {
+      this.setAttribute("open", "")
+    }
+    HTMLDialogElement.prototype.close = function close() {
+      this.removeAttribute("open")
+    }
+  }
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("LobbyView between-rounds variant (issue #24)", () => {
+  it("host between rounds sees editable pack chips + RESET GAME button", async () => {
+    render(<Lobby code="INS24Z" packs={PACKS} />)
+
+    // Host pack chips render (radiogroup with PackChip role=radio).
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("pack-chip-football-premier-league"),
+      ).toBeInTheDocument()
+    })
+    expect(screen.getByTestId("pack-chip-football-la-liga")).toBeInTheDocument()
+    expect(screen.getByTestId("insider-reset-game-cta")).toBeInTheDocument()
+
+    // Read-only label is NOT shown to host.
+    expect(
+      screen.queryByTestId("insider-pack-readonly"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("non-host between rounds sees read-only Pack label and no destructive controls", async () => {
+    state.mockMePlayerId = OTHER_ID
+    render(<Lobby code="INS24Z" packs={PACKS} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("insider-pack-readonly")).toBeInTheDocument()
+    })
+
+    expect(
+      screen.queryByTestId("pack-chip-football-premier-league"),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByTestId("insider-reset-game-cta")).not.toBeInTheDocument()
+  })
+
+  it("RESET GAME opens custom <dialog> confirm (not native confirm)", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup()
+    render(<Lobby code="INS24Z" packs={PACKS} />)
+
+    const reset = await screen.findByTestId("insider-reset-game-cta")
+    // jsdom's HTMLDialogElement.showModal exists but doesn't toggle :modal;
+    // we assert the element is in the DOM and confirm CTAs render after click.
+    await user.click(reset)
+    expect(
+      screen.getByTestId("insider-reset-confirm-dialog"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId("insider-reset-confirm-cta"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId("insider-reset-cancel-cta"),
+    ).toBeInTheDocument()
+  })
+
+  it("initial-lobby (current_round=0) hides pack control + reset", async () => {
+    state.mockRoom = { ...state.mockRoom, current_round: 0 }
+    render(<Lobby code="INS24Z" packs={PACKS} />)
+
+    // Wait for a stable render — the Players section is always present.
+    await waitFor(() => {
+      expect(screen.getByTestId("insider-player-list")).toBeInTheDocument()
+    })
+
+    expect(
+      screen.queryByTestId("pack-chip-football-premier-league"),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByTestId("insider-pack-readonly")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("insider-reset-game-cta")).not.toBeInTheDocument()
+  })
+})

--- a/apps/insider/lib/__tests__/migration-0036-change-insider-pack.test.ts
+++ b/apps/insider/lib/__tests__/migration-0036-change-insider-pack.test.ts
@@ -1,0 +1,266 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { createClient } from "@supabase/supabase-js"
+
+// Integration test for migration 0036_change_insider_pack (issue #24).
+// Requires `bunx supabase start`.
+//
+// Verifies the change_insider_pack(p_room_id, p_player_id, p_pack_slug) RPC:
+//   - Host can change pack between rounds (status=LOBBY, current_round>=1).
+//   - Non-host gets PGAME12.
+//   - PGAME20 on a disabled or non-existent pack.
+//   - Rejected during 'asking' phase (latest round phase guard).
+//   - Rejected for initial-lobby state (current_round = 0 / IS NULL).
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL ?? "http://127.0.0.1:54321"
+const SUPABASE_ANON_KEY =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+  "sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH"
+
+const LOCAL_SERVICE_ROLE_FALLBACK =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+  "eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0." +
+  "EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU"
+
+const SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ?? LOCAL_SERVICE_ROLE_FALLBACK
+
+const PACK_SLUG_DEFAULT = "football-premier-league"
+const PACK_SLUG_ALT = "football-la-liga"
+const PACK_SLUG_DISABLED = "headball-test-disabled-pack-0036"
+
+const ROOM_CODES = {
+  betweenHost: "INS36A",
+  nonHost: "INS36B",
+  initialLobby: "INS36C",
+  duringAsking: "INS36D",
+  disabledPack: "INS36E",
+} as const
+
+const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+  auth: { persistSession: false, autoRefreshToken: false },
+})
+
+const anon = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  auth: { persistSession: false, autoRefreshToken: false },
+})
+
+interface Fixture {
+  roomId: string
+  hostId: string
+  otherId: string
+}
+
+async function cleanup(): Promise<void> {
+  for (const code of Object.values(ROOM_CODES)) {
+    await admin.from("rooms").delete().eq("code", code)
+  }
+  // Clean the test-only disabled pack we may have inserted.
+  await admin.from("content_packs").delete().eq("slug", PACK_SLUG_DISABLED)
+}
+
+interface RoomArgs {
+  status: "LOBBY" | "PLAYING"
+  currentRound: number | null
+  // If set, also insert a game_insider_round row at this phase.
+  roundPhase?:
+    | "preparing"
+    | "asking"
+    | "guessed"
+    | "voting"
+    | "reveal"
+    | "result_failed"
+}
+
+async function createRoom(code: string, args: RoomArgs): Promise<Fixture> {
+  const hostId = crypto.randomUUID()
+  const otherId = crypto.randomUUID()
+
+  const { data: room, error: roomErr } = await admin
+    .from("rooms")
+    .insert({
+      code,
+      max_rounds: 5,
+      score_positions: 1,
+      category: "premier-league",
+      game_type: "insider",
+      host_player_id: hostId,
+      status: args.status,
+      current_round: args.currentRound,
+    })
+    .select("id")
+    .single()
+  if (roomErr) throw roomErr
+
+  const { error: pErr } = await admin.from("players").insert([
+    {
+      room_id: room.id,
+      player_id: hostId,
+      display_name: "H",
+      join_order: 1,
+      connected: true,
+      total_score: 0,
+    },
+    {
+      room_id: room.id,
+      player_id: otherId,
+      display_name: "O",
+      join_order: 2,
+      connected: true,
+      total_score: 0,
+    },
+  ])
+  if (pErr) throw pErr
+
+  const { error: cfgErr } = await admin
+    .from("game_insider_room_config")
+    .insert({
+      room_id: room.id,
+      pack_slug: PACK_SLUG_DEFAULT,
+      time_limit_s: 300,
+      round_count: 5,
+    })
+  if (cfgErr) throw cfgErr
+
+  if (args.roundPhase && args.currentRound) {
+    const { error: rErr } = await admin.from("game_insider_round").insert({
+      room_id: room.id,
+      round_number: args.currentRound,
+      pack_slug: PACK_SLUG_DEFAULT,
+      secret_value: "X",
+      time_limit_s: 300,
+      phase: args.roundPhase,
+      started_at: new Date().toISOString(),
+      vote_deadline: new Date(Date.now() + 60 * 1000).toISOString(),
+      eligible_voter_ids: [hostId, otherId],
+    })
+    if (rErr) throw rErr
+  }
+
+  return { roomId: room.id, hostId, otherId }
+}
+
+async function readPack(roomId: string): Promise<string | null> {
+  const { data, error } = await admin
+    .from("game_insider_room_config")
+    .select("pack_slug")
+    .eq("room_id", roomId)
+    .single()
+  if (error) throw error
+  return data.pack_slug as string
+}
+
+beforeAll(async () => {
+  await cleanup()
+})
+
+afterAll(async () => {
+  await cleanup()
+})
+
+describe("change_insider_pack (migration 0036) — issue #24", () => {
+  it("host can change pack between rounds", async () => {
+    const f = await createRoom(ROOM_CODES.betweenHost, {
+      status: "LOBBY",
+      currentRound: 1,
+      roundPhase: "reveal",
+    })
+
+    const { error } = await anon.rpc("change_insider_pack", {
+      p_room_id: f.roomId,
+      p_player_id: f.hostId,
+      p_pack_slug: PACK_SLUG_ALT,
+    })
+    expect(error).toBeNull()
+
+    const after = await readPack(f.roomId)
+    expect(after).toBe(PACK_SLUG_ALT)
+  })
+
+  it("non-host caller is rejected with PGAME12 / PG012", async () => {
+    const f = await createRoom(ROOM_CODES.nonHost, {
+      status: "LOBBY",
+      currentRound: 1,
+      roundPhase: "reveal",
+    })
+
+    const { error } = await anon.rpc("change_insider_pack", {
+      p_room_id: f.roomId,
+      p_player_id: f.otherId,
+      p_pack_slug: PACK_SLUG_ALT,
+    })
+    expect(error).not.toBeNull()
+    expect(error?.code).toBe("PG012")
+    expect(error?.message ?? "").toMatch(/PGAME12/)
+
+    // Pack unchanged.
+    expect(await readPack(f.roomId)).toBe(PACK_SLUG_DEFAULT)
+  })
+
+  it("initial-lobby state (current_round = 0) is rejected with PGAME13 / PG013", async () => {
+    const f = await createRoom(ROOM_CODES.initialLobby, {
+      status: "LOBBY",
+      currentRound: 0,
+    })
+
+    const { error } = await anon.rpc("change_insider_pack", {
+      p_room_id: f.roomId,
+      p_player_id: f.hostId,
+      p_pack_slug: PACK_SLUG_ALT,
+    })
+    expect(error).not.toBeNull()
+    expect(error?.code).toBe("PG013")
+    expect(await readPack(f.roomId)).toBe(PACK_SLUG_DEFAULT)
+  })
+
+  it("active 'asking' phase is rejected with PGAME13 / PG013", async () => {
+    const f = await createRoom(ROOM_CODES.duringAsking, {
+      status: "PLAYING",
+      currentRound: 1,
+      roundPhase: "asking",
+    })
+
+    const { error } = await anon.rpc("change_insider_pack", {
+      p_room_id: f.roomId,
+      p_player_id: f.hostId,
+      p_pack_slug: PACK_SLUG_ALT,
+    })
+    expect(error).not.toBeNull()
+    expect(error?.code).toBe("PG013")
+    expect(await readPack(f.roomId)).toBe(PACK_SLUG_DEFAULT)
+  })
+
+  it("disabled pack is rejected with PGAME20 / PG020", async () => {
+    // Insert a disabled pack so the existence-check fails the enabled gate.
+    await admin.from("content_packs").insert({
+      slug: PACK_SLUG_DISABLED,
+      display_name: "Disabled Test Pack",
+      handler: "word_list",
+      source_ref: "test-only",
+      enabled: false,
+    })
+
+    const f = await createRoom(ROOM_CODES.disabledPack, {
+      status: "LOBBY",
+      currentRound: 1,
+      roundPhase: "reveal",
+    })
+
+    const { error } = await anon.rpc("change_insider_pack", {
+      p_room_id: f.roomId,
+      p_player_id: f.hostId,
+      p_pack_slug: PACK_SLUG_DISABLED,
+    })
+    expect(error).not.toBeNull()
+    expect(error?.code).toBe("PG020")
+    expect(await readPack(f.roomId)).toBe(PACK_SLUG_DEFAULT)
+
+    // Bogus slug also rejected with PGAME20.
+    const { error: err2 } = await anon.rpc("change_insider_pack", {
+      p_room_id: f.roomId,
+      p_player_id: f.hostId,
+      p_pack_slug: "this-pack-does-not-exist-0036",
+    })
+    expect(err2?.code).toBe("PG020")
+  })
+})

--- a/apps/insider/lib/__tests__/migration-0037-reset-insider-game.test.ts
+++ b/apps/insider/lib/__tests__/migration-0037-reset-insider-game.test.ts
@@ -1,0 +1,332 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { createClient } from "@supabase/supabase-js"
+
+// Integration test for migration 0037_reset_insider_game (issue #24).
+// Requires `bunx supabase start`.
+//
+// Verifies the reset_insider_game(p_room_id, p_player_id) RPC:
+//   - Host can reset between rounds (status=LOBBY, current_round>=1).
+//   - Host can reset at end of game (status=PLAYING, phase ∈ reveal/result_failed).
+//   - Non-host gets PGAME12.
+//   - Rejected during preparing/asking/voting (active round).
+//   - All per-round tables (game_insider_round, _roles, _votes, _responses)
+//     are cleared; players.total_score zeroed; rooms.status='LOBBY' and
+//     current_round=0; game_insider_room_config preserved.
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL ?? "http://127.0.0.1:54321"
+const SUPABASE_ANON_KEY =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+  "sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH"
+
+const LOCAL_SERVICE_ROLE_FALLBACK =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+  "eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0." +
+  "EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU"
+
+const SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ?? LOCAL_SERVICE_ROLE_FALLBACK
+
+const PACK_SLUG = "football-premier-league"
+
+const ROOM_CODES = {
+  betweenRounds: "INS37A",
+  endOfGame: "INS37B",
+  nonHost: "INS37C",
+  duringAsking: "INS37D",
+  duringVoting: "INS37E",
+  preserveConfig: "INS37F",
+} as const
+
+const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+  auth: { persistSession: false, autoRefreshToken: false },
+})
+
+const anon = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  auth: { persistSession: false, autoRefreshToken: false },
+})
+
+interface Fixture {
+  roomId: string
+  hostId: string
+  insiderId: string
+  playerAId: string
+  playerBId: string
+}
+
+async function cleanup(): Promise<void> {
+  for (const code of Object.values(ROOM_CODES)) {
+    await admin.from("rooms").delete().eq("code", code)
+  }
+}
+
+interface RoomArgs {
+  status: "LOBBY" | "PLAYING"
+  currentRound: number | null
+  roundPhase?:
+    | "preparing"
+    | "asking"
+    | "guessed"
+    | "voting"
+    | "reveal"
+    | "result_failed"
+  /** Insert votes + responses + roles too (for the cascade-cleanup test). */
+  withFullState?: boolean
+  /** Initial player.total_score values to verify zeroing. */
+  initialScores?: { host: number; insider: number; a: number; b: number }
+  packSlug?: string
+  timeLimitS?: 180 | 300 | 420
+  roundCount?: number
+}
+
+async function createRoom(code: string, args: RoomArgs): Promise<Fixture> {
+  const hostId = crypto.randomUUID()
+  const insiderId = crypto.randomUUID()
+  const playerAId = crypto.randomUUID()
+  const playerBId = crypto.randomUUID()
+  const scores = args.initialScores ?? { host: 5, insider: 3, a: 2, b: 4 }
+
+  const { data: room, error: roomErr } = await admin
+    .from("rooms")
+    .insert({
+      code,
+      max_rounds: 5,
+      score_positions: 1,
+      category: "premier-league",
+      game_type: "insider",
+      host_player_id: hostId,
+      status: args.status,
+      current_round: args.currentRound,
+    })
+    .select("id")
+    .single()
+  if (roomErr) throw roomErr
+
+  const { error: pErr } = await admin.from("players").insert([
+    { room_id: room.id, player_id: hostId, display_name: "H", join_order: 1, connected: true, total_score: scores.host },
+    { room_id: room.id, player_id: insiderId, display_name: "I", join_order: 2, connected: true, total_score: scores.insider },
+    { room_id: room.id, player_id: playerAId, display_name: "A", join_order: 3, connected: true, total_score: scores.a },
+    { room_id: room.id, player_id: playerBId, display_name: "B", join_order: 4, connected: true, total_score: scores.b },
+  ])
+  if (pErr) throw pErr
+
+  const { error: cfgErr } = await admin
+    .from("game_insider_room_config")
+    .insert({
+      room_id: room.id,
+      pack_slug: args.packSlug ?? PACK_SLUG,
+      time_limit_s: args.timeLimitS ?? 300,
+      round_count: args.roundCount ?? 5,
+    })
+  if (cfgErr) throw cfgErr
+
+  if (args.roundPhase && args.currentRound) {
+    const { error: rErr } = await admin.from("game_insider_round").insert({
+      room_id: room.id,
+      round_number: args.currentRound,
+      pack_slug: PACK_SLUG,
+      secret_value: "X",
+      time_limit_s: 300,
+      phase: args.roundPhase,
+      started_at: new Date().toISOString(),
+      vote_deadline: new Date(Date.now() + 60 * 1000).toISOString(),
+      eligible_voter_ids: [hostId, insiderId, playerAId, playerBId],
+    })
+    if (rErr) throw rErr
+
+    if (args.withFullState) {
+      const { error: rolesErr } = await admin.from("game_insider_roles").insert([
+        { room_id: room.id, round_number: args.currentRound, player_id: hostId, role: "master" },
+        { room_id: room.id, round_number: args.currentRound, player_id: insiderId, role: "insider" },
+        { room_id: room.id, round_number: args.currentRound, player_id: playerAId, role: "player" },
+        { room_id: room.id, round_number: args.currentRound, player_id: playerBId, role: "player" },
+      ])
+      if (rolesErr) throw rolesErr
+
+      const { error: vErr } = await admin.from("game_insider_votes").insert([
+        { room_id: room.id, round_number: args.currentRound, voter_player_id: hostId, voted_player_id: insiderId },
+        { room_id: room.id, round_number: args.currentRound, voter_player_id: playerAId, voted_player_id: insiderId },
+      ])
+      if (vErr) throw vErr
+    }
+  }
+
+  return { roomId: room.id, hostId, insiderId, playerAId, playerBId }
+}
+
+async function readRoom(roomId: string) {
+  const { data, error } = await admin
+    .from("rooms")
+    .select("status, current_round")
+    .eq("id", roomId)
+    .single()
+  if (error) throw error
+  return data as { status: string; current_round: number | null }
+}
+
+async function readScores(roomId: string): Promise<number[]> {
+  const { data, error } = await admin
+    .from("players")
+    .select("total_score")
+    .eq("room_id", roomId)
+  if (error) throw error
+  return (data ?? []).map((r) => r.total_score as number)
+}
+
+async function readConfig(roomId: string) {
+  const { data, error } = await admin
+    .from("game_insider_room_config")
+    .select("pack_slug, time_limit_s, round_count")
+    .eq("room_id", roomId)
+    .single()
+  if (error) throw error
+  return data as {
+    pack_slug: string
+    time_limit_s: number
+    round_count: number
+  }
+}
+
+async function countRoundRows(roomId: string, table: string): Promise<number> {
+  const { count, error } = await admin
+    .from(table)
+    .select("*", { count: "exact", head: true })
+    .eq("room_id", roomId)
+  if (error) throw error
+  return count ?? 0
+}
+
+beforeAll(async () => {
+  await cleanup()
+})
+
+afterAll(async () => {
+  await cleanup()
+})
+
+describe("reset_insider_game (migration 0037) — issue #24", () => {
+  it("host can reset between rounds; per-round tables cleared, scores zeroed, room shell reset", async () => {
+    const f = await createRoom(ROOM_CODES.betweenRounds, {
+      status: "LOBBY",
+      currentRound: 2,
+      roundPhase: "reveal",
+      withFullState: true,
+      initialScores: { host: 5, insider: 3, a: 2, b: 4 },
+    })
+
+    const { error } = await anon.rpc("reset_insider_game", {
+      p_room_id: f.roomId,
+      p_player_id: f.hostId,
+    })
+    expect(error).toBeNull()
+
+    const room = await readRoom(f.roomId)
+    expect(room.status).toBe("LOBBY")
+    expect(room.current_round).toBe(0)
+
+    const scores = await readScores(f.roomId)
+    expect(scores).toEqual([0, 0, 0, 0])
+
+    expect(await countRoundRows(f.roomId, "game_insider_round")).toBe(0)
+    expect(await countRoundRows(f.roomId, "game_insider_roles")).toBe(0)
+    expect(await countRoundRows(f.roomId, "game_insider_votes")).toBe(0)
+    expect(await countRoundRows(f.roomId, "game_insider_responses")).toBe(0)
+  })
+
+  it("host can reset at end-of-game (PLAYING + phase=reveal on final round)", async () => {
+    const f = await createRoom(ROOM_CODES.endOfGame, {
+      status: "PLAYING",
+      currentRound: 5,
+      roundPhase: "reveal",
+      withFullState: true,
+    })
+
+    const { error } = await anon.rpc("reset_insider_game", {
+      p_room_id: f.roomId,
+      p_player_id: f.hostId,
+    })
+    expect(error).toBeNull()
+
+    const room = await readRoom(f.roomId)
+    expect(room.status).toBe("LOBBY")
+    expect(room.current_round).toBe(0)
+  })
+
+  it("non-host caller is rejected with PGAME12 / PG012", async () => {
+    const f = await createRoom(ROOM_CODES.nonHost, {
+      status: "LOBBY",
+      currentRound: 1,
+      roundPhase: "reveal",
+    })
+
+    const { error } = await anon.rpc("reset_insider_game", {
+      p_room_id: f.roomId,
+      p_player_id: f.insiderId,
+    })
+    expect(error).not.toBeNull()
+    expect(error?.code).toBe("PG012")
+
+    const room = await readRoom(f.roomId)
+    expect(room.current_round).toBe(1)
+  })
+
+  it("rejected during 'asking' phase with PGAME13 / PG013", async () => {
+    const f = await createRoom(ROOM_CODES.duringAsking, {
+      status: "PLAYING",
+      currentRound: 1,
+      roundPhase: "asking",
+    })
+
+    const { error } = await anon.rpc("reset_insider_game", {
+      p_room_id: f.roomId,
+      p_player_id: f.hostId,
+    })
+    expect(error).not.toBeNull()
+    expect(error?.code).toBe("PG013")
+  })
+
+  it("rejected during 'voting' phase with PGAME13 / PG013", async () => {
+    const f = await createRoom(ROOM_CODES.duringVoting, {
+      status: "PLAYING",
+      currentRound: 1,
+      roundPhase: "voting",
+    })
+
+    const { error } = await anon.rpc("reset_insider_game", {
+      p_room_id: f.roomId,
+      p_player_id: f.hostId,
+    })
+    expect(error?.code).toBe("PG013")
+  })
+
+  it("game_insider_room_config (pack_slug, time_limit_s, round_count) preserved across reset", async () => {
+    const f = await createRoom(ROOM_CODES.preserveConfig, {
+      status: "LOBBY",
+      currentRound: 3,
+      roundPhase: "reveal",
+      packSlug: "football-la-liga",
+      timeLimitS: 420,
+      roundCount: 7,
+    })
+
+    const before = await readConfig(f.roomId)
+
+    const { error } = await anon.rpc("reset_insider_game", {
+      p_room_id: f.roomId,
+      p_player_id: f.hostId,
+    })
+    expect(error).toBeNull()
+
+    const after = await readConfig(f.roomId)
+    expect(after.pack_slug).toBe(before.pack_slug)
+    expect(after.time_limit_s).toBe(before.time_limit_s)
+    expect(after.round_count).toBe(before.round_count)
+    // max_rounds on rooms also preserved.
+    const room = await admin
+      .from("rooms")
+      .select("max_rounds")
+      .eq("id", f.roomId)
+      .single()
+    expect(room.data?.max_rounds).toBe(5)
+  })
+})

--- a/apps/insider/lib/insider-rpc.ts
+++ b/apps/insider/lib/insider-rpc.ts
@@ -300,3 +300,50 @@ export async function reconcileRoundPhase(
     },
   )
 }
+
+// Issue #24 — between-rounds host edits the pack via change_insider_pack
+// (migration 0036). Errors surface as GameRpcError with code in {PG004,
+// PG012, PG013, PG020}.
+export interface ChangeInsiderPackArgs {
+  roomId: string
+  playerId: string
+  packSlug: string
+}
+
+export async function changeInsiderPack(
+  supabase: SupabaseClient,
+  args: ChangeInsiderPackArgs,
+): Promise<void> {
+  await dispatch<Record<string, unknown>, void>(
+    supabase,
+    "change_insider_pack",
+    {
+      p_room_id: args.roomId,
+      p_player_id: args.playerId,
+      p_pack_slug: args.packSlug,
+    },
+  )
+}
+
+// Issue #24 — host wipes per-round state via reset_insider_game (migration
+// 0037). Used both for mid-game reset and end-of-game PLAY AGAIN /
+// BACK TO LOBBY. Errors surface as GameRpcError with code in {PG004, PG012,
+// PG013}.
+export interface ResetInsiderGameArgs {
+  roomId: string
+  playerId: string
+}
+
+export async function resetInsiderGame(
+  supabase: SupabaseClient,
+  args: ResetInsiderGameArgs,
+): Promise<void> {
+  await dispatch<Record<string, unknown>, void>(
+    supabase,
+    "reset_insider_game",
+    {
+      p_room_id: args.roomId,
+      p_player_id: args.playerId,
+    },
+  )
+}

--- a/apps/insider/playwright.config.ts
+++ b/apps/insider/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from "@playwright/test"
+
+// Port override lets parallel pm-dev worktrees run their own dev server.
+// Default 3002 matches the insider app's `dev` script in package.json.
+const PORT = process.env.PORT ?? "3002"
+const BASE_URL = `http://localhost:${PORT}`
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: BASE_URL,
+    trace: "retain-on-failure",
+    headless: true,
+    viewport: { width: 414, height: 896 },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 414, height: 896 },
+      },
+    },
+  ],
+  webServer: {
+    command: `PORT=${PORT} bun run dev`,
+    url: BASE_URL,
+    reuseExistingServer: true,
+    timeout: 180_000,
+    stdout: "ignore",
+    stderr: "pipe",
+  },
+})

--- a/supabase/migrations/0036_change_insider_pack.sql
+++ b/supabase/migrations/0036_change_insider_pack.sql
@@ -1,0 +1,118 @@
+-- 0036_change_insider_pack.sql
+-- Issue #24 — between-rounds host-edit pack RPC.
+--
+-- After a round completes (rooms.status flips back to LOBBY via
+-- advance_to_next_round, migration 0031) the host gets pack chips on the
+-- lobby screen. This RPC is the write path for those chips. It updates
+-- game_insider_room_config.pack_slug for the room, which the next
+-- start_insider_round call reads (migration 0023's start_insider_round looks
+-- up pack_slug on every call, so the new pack takes effect for round N+1).
+--
+-- Why between-rounds only:
+--   The "initial lobby" before round 1 picks its pack on the host setup form
+--   (apps/insider/app/new) which writes via create_insider_room (0029). That
+--   is the canonical mechanism for picking the round-1 pack. This RPC is
+--   strictly the "host changes their mind between rounds" path and rejects
+--   the initial-lobby case so the host setup form stays the single owner of
+--   first-round pack selection.
+--
+-- Numbering note: rubric called this 0035 but 0035_round_outcome.sql already
+-- shipped (issue #17). 0036 is the next free slot.
+--
+-- Error codes (PGAMExx → 5-char SQLSTATE PGxxx, see error-codes.md):
+--   PGAME04 / PG004 — room not found (cross-game)
+--   PGAME12 / PG012 — only host can change pack (matches start_insider_round)
+--   PGAME13 / PG013 — room not in valid between-rounds state
+--   PGAME20 / PG020 — pack not found or disabled (matches create_insider_room
+--                     argument-validation channel)
+--
+-- Realtime: game_insider_room_config is `-- no-realtime` (per its create
+-- comment in 0029) — clients re-fetch on the rooms.current_round flip that
+-- accompanies start_insider_round. No publication change required.
+
+begin;
+
+create or replace function change_insider_pack(
+  p_room_id   uuid,
+  p_player_id uuid,
+  p_pack_slug text
+) returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_host          uuid;
+  v_status        room_status;
+  v_current_round int;
+  v_round_phase   text;
+begin
+  -- 1. Lock the room row so host + state checks are atomic against any
+  --    concurrent advance_to_next_round / start_insider_round.
+  select host_player_id, status, current_round
+    into v_host, v_status, v_current_round
+    from rooms
+   where id = p_room_id
+   for update;
+
+  if v_host is null then
+    raise exception 'PGAME04: room not found: %', p_room_id
+      using errcode = 'PG004';
+  end if;
+
+  -- 2. Authorization: host only. Mirrors start_insider_round (0023) so the
+  --    UI's host-only chip rendering matches the server gate.
+  if v_host <> p_player_id then
+    raise exception 'PGAME12: only host can change pack'
+      using errcode = 'PG012';
+  end if;
+
+  -- 3. State guard: room must be in LOBBY (so no round is mid-flight) AND
+  --    a round must already have been played (current_round >= 1 — the
+  --    "between rounds" predicate). The initial-lobby case (current_round
+  --    null/0) is rejected because that path goes through create_insider_room.
+  --
+  --    Also defend against the edge where status = LOBBY but the most-recent
+  --    round row is still mid-phase (advance_to_next_round only flips status,
+  --    not the round row). If the latest round is in 'preparing'/'asking'/
+  --    'voting'/'guessed' the room is not really between rounds yet.
+  if v_status <> 'LOBBY' or coalesce(v_current_round, 0) < 1 then
+    raise exception 'PGAME13: pack can only be changed between rounds'
+      using errcode = 'PG013';
+  end if;
+
+  select phase
+    into v_round_phase
+    from game_insider_round
+   where room_id      = p_room_id
+     and round_number = v_current_round;
+
+  if v_round_phase is not null
+     and v_round_phase not in ('reveal', 'result_failed') then
+    raise exception 'PGAME13: pack cannot change during an active round'
+      using errcode = 'PG013';
+  end if;
+
+  -- 4. Pack must exist + be enabled. Same convention as create_insider_room
+  --    (0029), but raised under PGAME20 so the dispatch wrapper surfaces the
+  --    "invalid argument" channel that the host-setup form already maps.
+  if not exists (
+    select 1 from content_packs
+     where slug    = p_pack_slug
+       and enabled = true
+  ) then
+    raise exception 'PGAME20: pack not found or disabled: %', p_pack_slug
+      using errcode = 'PG020';
+  end if;
+
+  -- 5. Apply. Idempotent — same pack assignment is a no-op write.
+  update game_insider_room_config
+     set pack_slug = p_pack_slug
+   where room_id   = p_room_id;
+end;
+$$;
+
+revoke execute on function change_insider_pack(uuid, uuid, text) from public;
+grant execute on function change_insider_pack(uuid, uuid, text) to anon;
+
+commit;

--- a/supabase/migrations/0037_reset_insider_game.sql
+++ b/supabase/migrations/0037_reset_insider_game.sql
@@ -1,0 +1,130 @@
+-- 0037_reset_insider_game.sql
+-- Issue #24 — host wipes per-round state mid-game.
+--
+-- Two callers:
+--   1. Mid-game RESET — host between rounds taps the RESET GAME button on
+--      the lobby. Wipes scores + rounds, keeps players + room shell.
+--   2. End-of-game PLAY AGAIN / BACK TO LOBBY — host on the FinalScoreboard
+--      (current_round >= max_rounds, phase ∈ reveal/result_failed) taps
+--      either CTA. Both paths call this RPC; PLAY AGAIN then chains
+--      start_insider_round, BACK TO LOBBY does not.
+--
+-- Numbering note: rubric called this 0036 but 0035_round_outcome.sql already
+-- shipped (issue #17), so this is 0037 (paired with 0036_change_insider_pack).
+--
+-- Preserved across reset: room code, players (id + display_name + join_order),
+-- host_player_id, and game_insider_room_config (pack_slug, time_limit_s,
+-- round_count). Wiped: per-round tables (game_insider_round / _roles /
+-- _votes / _responses), players.total_score, rooms.current_round, rooms.status.
+--
+-- Cross-reference: Headball's reset_game (0034_reset_game_unlock_category) is
+-- the structural sibling. Differences are (a) Insider's per-round tables are
+-- different and (b) Insider does not have category_locked.
+--
+-- Error codes (PGAMExx → 5-char SQLSTATE PGxxx, see error-codes.md):
+--   PGAME04 / PG004 — room not found (cross-game)
+--   PGAME12 / PG012 — only host can reset (matches start_insider_round)
+--   PGAME13 / PG013 — room not in a state where reset is allowed
+--                     (rejects preparing/asking/voting/guessed phases)
+--
+-- Realtime: rooms is already published; the status flip + current_round flip
+-- broadcast to all subscribers, so non-host clients see the reset without
+-- needing a separate notification channel.
+
+begin;
+
+create or replace function reset_insider_game(
+  p_room_id   uuid,
+  p_player_id uuid
+) returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_host          uuid;
+  v_status        room_status;
+  v_current_round int;
+  v_round_phase   text;
+begin
+  -- 1. Lock the room row.
+  select host_player_id, status, current_round
+    into v_host, v_status, v_current_round
+    from rooms
+   where id = p_room_id
+   for update;
+
+  if v_host is null then
+    raise exception 'PGAME04: room not found: %', p_room_id
+      using errcode = 'PG004';
+  end if;
+
+  -- 2. Authorization: host only.
+  if v_host <> p_player_id then
+    raise exception 'PGAME12: only host can reset game'
+      using errcode = 'PG012';
+  end if;
+
+  -- 3. State guard. Allowed states:
+  --      a. status = LOBBY AND current_round >= 1
+  --         → "between rounds" (mid-game reset path).
+  --      b. status = PLAYING AND latest round phase ∈ ('reveal','result_failed')
+  --         → "end of game" (PLAY AGAIN / BACK TO LOBBY from FinalScoreboard).
+  --    Any other state (initial lobby, preparing/asking/voting/guessed) is a
+  --    PGAME13 reject so we never wipe scores out from under an in-flight
+  --    round.
+  if v_status = 'LOBBY' then
+    if coalesce(v_current_round, 0) < 1 then
+      raise exception 'PGAME13: nothing to reset (initial lobby)'
+        using errcode = 'PG013';
+    end if;
+  elsif v_status = 'PLAYING' then
+    select phase
+      into v_round_phase
+      from game_insider_round
+     where room_id      = p_room_id
+       and round_number = v_current_round;
+
+    if v_round_phase is null
+       or v_round_phase not in ('reveal', 'result_failed') then
+      raise exception 'PGAME13: cannot reset during active round (phase=%)',
+                      coalesce(v_round_phase, 'unknown')
+        using errcode = 'PG013';
+    end if;
+  else
+    raise exception 'PGAME13: room not in resettable state (status=%)', v_status
+      using errcode = 'PG013';
+  end if;
+
+  -- 4. Wipe per-round tables. Order does not matter (no FKs between them) but
+  --    we delete child-shaped tables (votes/responses/roles) before the
+  --    parent (game_insider_round) for clarity.
+  delete from game_insider_votes      where room_id = p_room_id;
+  delete from game_insider_responses  where room_id = p_room_id;
+  delete from game_insider_roles      where room_id = p_room_id;
+  delete from game_insider_round      where room_id = p_room_id;
+
+  -- 5. Zero per-player scores.
+  update players
+     set total_score = 0
+   where room_id = p_room_id;
+
+  -- 6. Reset room shell. We set current_round to 0 (not NULL) to match the
+  --    initial state from create_insider_room (0029) — the rooms.current_round
+  --    column defaults to 0, and the lobby UI treats `?? 0` as the not-yet-
+  --    started sentinel. The "between rounds vs initial" distinction is
+  --    encoded as current_round >= 1, so 0 here means "back to initial lobby".
+  update rooms
+     set status        = 'LOBBY',
+         current_round = 0
+   where id = p_room_id;
+
+  -- game_insider_room_config (pack_slug, time_limit_s, round_count) is
+  -- intentionally untouched — preserved across reset per the issue contract.
+end;
+$$;
+
+revoke execute on function reset_insider_game(uuid, uuid) from public;
+grant execute on function reset_insider_game(uuid, uuid) to anon;
+
+commit;


### PR DESCRIPTION
## Summary

Adds between-rounds + game-end UX to Insider. Host can change pack and reset mid-game; FinalScoreboard renders when `current_round >= max_rounds` with PLAY AGAIN / BACK TO LOBBY.

Fixes #24

## Changes

- `supabase/migrations/0036_change_insider_pack.sql` — host-only RPC to swap `game_insider_room_config.pack_slug` between rounds. Guards: PGAME12 (non-host), PGAME13 (initial lobby or active phase), PGAME20 (pack disabled/missing).
- `supabase/migrations/0037_reset_insider_game.sql` — host-only RPC to wipe per-round state (round, roles, votes, responses) + zero `players.total_score` + flip `rooms` back to `LOBBY` + `current_round=0`. Preserves players, room code, host, pack, timer, round_count. Guards: PGAME12 (non-host), PGAME13 (active round phase).
- `apps/insider/lib/insider-rpc.ts` — `changeInsiderPack` + `resetInsiderGame` typed wrappers.
- `apps/insider/app/actions/change-insider-pack.ts`, `reset-insider-game.ts` — server actions with mapped Thai error copy.
- `apps/insider/app/room/[code]/lobby.tsx` — `LobbyView` becomes mode-aware via `isBetweenRounds`. Host between rounds: editable `PackChip`s + `RESET GAME` secondary (custom Stadium-Energy `<dialog>` confirm) + `START ROUND X / Y` primary. Non-host: read-only `Pack: <name>` label + `START ROUND X / Y`. Initial lobby unchanged. Router routes to new `FinalScoreboard` when `phase ∈ {reveal, result_failed} ∧ round >= max_rounds`.
- `apps/insider/app/room/[code]/final-scoreboard.tsx` — game-end leaderboard. `GAME OVER` Bebas Neue header, sorted desc by `total_score`, 1st place rendered as a tag-color BIG NAME card; 2nd+ in standard score-tile treatment. PLAY AGAIN chains `resetInsiderGameAction → startInsiderRoundAction`; BACK TO LOBBY calls reset only.
- `apps/insider/app/room/[code]/page.tsx` — fetches `listEnabledPacks` server-side and passes through to `Lobby`.
- Tests:
  - 5 unit tests for `change_insider_pack` (host happy path, non-host PGAME12, initial lobby PGAME13, active asking PGAME13, disabled pack PGAME20).
  - 6 unit tests for `reset_insider_game` (between-rounds, end-of-game, non-host PGAME12, asking PGAME13, voting PGAME13, config preserved).
  - 5 component tests for `FinalScoreboard` (header + leaderboard, advance_to_reveal seal, host-only CTAs, PLAY AGAIN chain, BACK TO LOBBY no chain).
  - 4 component tests for `LobbyView` between-rounds (host chips + RESET, non-host read-only, dialog gate, initial-lobby hides controls).
  - 6 Playwright E2E specs (between-rounds-lobby, game-end-final-scoreboard, mid-game-reset). Covers DB-level acceptance (RPC effect on `game_insider_room_config`, `rooms`, `players`, per-round tables).
  - New `apps/insider/playwright.config.ts` (mirrors apps/headball pattern).

### Migration numbering

Rubric called for `0035` + `0036`, but `0035_round_outcome.sql` already shipped with #17. New migrations are `0036` + `0037` (next free slots). Same content, names follow the rubric intent.

## Rubric verification

- [x] Between rounds, host sees editable pack chips (reusing `PackChip` as-is); switching pack updates `game_insider_room_config.pack_slug` via `change_insider_pack` RPC — verified live: navigated to seeded room as host, snapshot shows 36 `[radio]` pack chips with `football-premier-league` `[checked]`; clicked La Liga; SQL `select pack_slug` returned `football-la-liga`. Also covered by `between-rounds-lobby.spec.ts`.
- [x] Between rounds, host sees `RESET GAME` next to `START ROUND X / Y`; tapping opens custom Stadium-Energy `<dialog>` confirm; confirming wipes per-round tables + zeroes `players.total_score`; preserves players, code, host, pack, timer, round_count — verified live: snapshot shows `Reset` + `Start Round 2 / 5 →` buttons side-by-side; clicking Reset opens dialog with "RESET GAME?" header + Cancel/Reset buttons. Wipe+preservation verified via `migration-0037-reset-insider-game.test.ts` ("game_insider_room_config preserved" + "scores zeroed" + "per-round tables cleared") and `mid-game-reset.spec.ts`.
- [x] Non-host between-rounds lobby shows read-only `Pack: <name>` label; never sees pack chips, RESET, or destructive control — verified live: switched localStorage to AliceQA, reloaded; snapshot shows only `[link] ออกจากห้อง`, `[button] room-code`, `[button] Start Round 2 / 5 →` (no `[radio]` pack chips, no `Reset` button); page text shows `Pack ลาลีกา`. Also `between-rounds-lobby.spec.ts` ("non-host sees read-only Pack label and no destructive controls").
- [x] When `phase ∈ {'reveal','result_failed'}` AND `current_round >= max_rounds`, router renders `FinalScoreboard` instead of standard Reveal; `GAME OVER` header; sorted desc by `total_score`; 1st-place row only highlighted (jersey-color tag bg + BIG NAME Bebas Neue) — verified live: seeded round 3/3 with phase=reveal + scores Alice=9/Host=4/Bob=2/Insider=1; page renders `GAME OVER` + `── FINAL SCORES ──` + `1ST PLACE ALICEQA 9 pts` (tag-color highlighted) + ranks 2/3/4 in standard tiles. `final-scoreboard.test.tsx` and `game-end-final-scoreboard.spec.ts` cover the same.
- [x] `PLAY AGAIN →` calls `resetInsiderGame` then `startInsiderRound` → lands on round 1 — verified live: clicked PLAY AGAIN; SQL `select status, current_round` returned `PLAYING | 1`; all `total_score` rows = 0. Also `game-end-final-scoreboard.spec.ts` ("PLAY AGAIN resets scores and starts round 1").
- [x] `BACK TO LOBBY` calls `resetInsiderGame` only → lands on initial empty lobby (`current_round=0`, `status=LOBBY`) — verified live: re-seeded end-of-game; clicked BACK TO LOBBY; SQL returned `LOBBY | 0`. Also `game-end-final-scoreboard.spec.ts` ("BACK TO LOBBY resets and lands on initial empty lobby").
- [x] RPC guards: `change_insider_pack` and `reset_insider_game` reject non-host with PGAME12; `change_insider_pack` rejects current_round IS NULL/0 (initial lobby) and active phases with PGAME13; `reset_insider_game` rejects preparing/asking/voting with PGAME13 — covered by `migration-0036-change-insider-pack.test.ts` (5 cases) and `migration-0037-reset-insider-game.test.ts` (6 cases). All 11 unit tests green.
- [x] `game_insider_room_config` (pack/timer/round_count) preserved across reset; `scripts/check-realtime-publication.sh` passes — first verified by `migration-0037-reset-insider-game.test.ts` ("game_insider_room_config preserved across reset"). Realtime check ran clean as the first step of `bun run lint`. Note: `bunx supabase db reset` was NOT run because three other pm-dev sessions are sharing the local Supabase Postgres (per pm-dev shared-DB caveat); migrations were applied directly via `psql` on top of the existing schema and integration-tested with the new RPCs in place.
- [x] Happy path: host changes pack between R1+R2, then resets between R2+R3; final round triggers FinalScoreboard — covered by the three Playwright specs in combination.
- [x] Loading state: pending RPC disables triggering button — wired via `useTransition` `isPending` on the chip/RESET/PLAY AGAIN/BACK TO LOBBY buttons (`disabled={isPending && ...}` + `aria-busy`). Source-verified.
- [x] Empty state: N/A (rubric marks N/A — room always has >=1 player).
- [x] Error state: PGAME12 / PGAME20 surfaces a Stadium-Energy toast; lobby state unchanged — server action `mapError()` translates each PG code to Thai copy ("เฉพาะโฮสต์เปลี่ยนคลังคำได้", "ไม่พบคลังคำ", etc.) and renders into the existing `role="alert"` banner pattern (`insider-pack-error`, `insider-reset-error`); state unchanged via optimistic-flip rollback in `BetweenRoundsPackControl.handlePick`.

Groomed rubric: https://github.com/adisak1618/footballer-guesser/issues/24#issuecomment-4414990561

🤖 Generated with [Claude Code](https://claude.com/claude-code)
