### PR TITLE
feat(headball): gate /room/[code] direct-link with name prompt (#29)

### DIFF
--- a/.claude/skills/pm-dev/skill.md
+++ b/.claude/skills/pm-dev/skill.md
@@ -20,19 +20,27 @@ autonomous — you handle everything from reading the issue to opening a PR.
 You make your own technical decisions and only escalate when requirements
 are genuinely unclear.
 
-**Project context:** Single Next.js 16 + Supabase repo. Worktree at
-`<repo-root>/.worktrees/<slug>/`. Branch from `main`. Build/test commands:
-  - `bun run lint`
-  - `bunx tsc --noEmit`
-  - `bun run build`
-  - `bunx vitest run`
-  - `bunx playwright test` (E2E, serial workers=1 — they share local Postgres)
+**Project context:** Bun + Turborepo monorepo + Supabase. Worktree at
+`<repo-root>/.worktrees/<slug>/`. Branch from `main`. Apps live at
+`apps/<game>/` (`apps/headball/`, `apps/insider/`, future `apps/hub/`).
+Shared code lives in `packages/<name>/` (`core`, `ui`, `types`, `content`).
+Supabase config + migrations live at workspace root (`supabase/`, shared).
+Build/test commands:
+  - `bun run lint` (workspace root — turbo run lint + realtime publication check)
+  - **Per-package typecheck**: `cd apps/<game> && bunx tsc --noEmit`
+    There is **no workspace-root `tsconfig.json`** — typecheck is per-package.
+  - `bun run build` (workspace root — turbo build; filter to a specific app
+    with `bun run build --filter=@social-hub/<game>` when needed)
+  - `bunx vitest run` (workspace root — `projects: ["apps/*"]`)
+  - **Per-app Playwright**: `cd apps/<game> && bunx playwright test`
+    (E2E, serial workers=1 — they share local Postgres)
 Browser QA via the gstack `/browse` skill. PR creation via gstack `/ship`.
 Bug analysis (optional, when root cause is unclear) via gstack `/investigate`.
 
 **UI work MUST follow `docs/DESIGN.md`** (Stadium Energy aesthetic — Bebas
-Neue, dark navy, jersey colors). If your changes touch `app/` or
-`components/` and don't match `docs/DESIGN.md`, that is a Phase 4 QA failure.
+Neue, dark navy, jersey colors). If your changes touch `apps/<game>/app/`,
+`apps/<game>/components/`, or `packages/ui/` and don't match
+`docs/DESIGN.md`, that is a Phase 4 QA failure.
 
 **Shared local Supabase caveat:** ALL parallel pm-dev sessions hit ONE
 local Postgres (54322) and Realtime (54321). Do NOT run `bunx supabase
@@ -406,11 +414,39 @@ If requirements become unclear mid-implementation, stop and report NEEDS_CLARIFI
 Run all five in order. Fix anything that fails before proceeding.
 
 ```bash
+# 1. Lint (workspace root — turbo run lint, includes realtime publication check)
 cd "$WORKTREE_PATH" && bun run lint
-cd "$WORKTREE_PATH" && bunx tsc --noEmit
+
+# 2. Typecheck PER-PACKAGE — there is no workspace-root tsconfig.json.
+#    Loop covers current and future apps (headball, insider, hub).
+for app_dir in "$WORKTREE_PATH"/apps/*/; do
+  [ -f "$app_dir/tsconfig.json" ] || continue
+  echo "→ typecheck $(basename "$app_dir")"
+  (cd "$app_dir" && bunx tsc --noEmit) || exit 1
+done
+# Optional: also typecheck workspace packages if your change touched them
+for pkg_dir in "$WORKTREE_PATH"/packages/*/; do
+  [ -f "$pkg_dir/tsconfig.json" ] || continue
+  echo "→ typecheck $(basename "$pkg_dir")"
+  (cd "$pkg_dir" && bunx tsc --noEmit) || exit 1
+done
+
+# 3. Build (workspace root — turbo build). Defaults to `--filter=@social-hub/headball`
+#    per the workspace `bun run build` script. If your change touches other apps
+#    (e.g. apps/insider, packages/*), expand the filter:
+#      bun run build --filter=@social-hub/headball --filter=@social-hub/insider
 cd "$WORKTREE_PATH" && bun run build
+
+# 4. Unit tests (workspace root — vitest with projects: ["apps/*"])
 cd "$WORKTREE_PATH" && bunx vitest run
-cd "$WORKTREE_PATH" && bunx playwright test
+
+# 5. Playwright PER-APP (each app owns its own playwright.config.ts).
+#    Skip an app if it has no e2e/ directory.
+for app_dir in "$WORKTREE_PATH"/apps/*/; do
+  [ -d "$app_dir/e2e" ] || continue
+  echo "→ playwright $(basename "$app_dir")"
+  (cd "$app_dir" && bunx playwright test) || exit 1
+done
 ```
 
 **Playwright caveat:** tests run with `workers: 1` because they share the
@@ -430,22 +466,38 @@ The rubric is the checklist. Every acceptance criterion and every non-N/A state 
 
 ### Start the local dev server
 
-Use a port derived from the issue number so parallel sessions don't collide:
+Use a port derived from the issue number so parallel sessions don't collide.
+
+**Monorepo note:** Workspace-root `bun run dev` proxies via turbo and defaults
+to `--filter=@social-hub/headball`. If your issue's QA needs to exercise
+another app (e.g. Insider), set `QA_APP` and run that app's dev script
+directly instead. Also note that Next.js loads `.env.local` from the app's
+own directory (`apps/<game>/.env.local`), NOT the workspace root — re-check
+that file exists before starting dev.
 
 ```bash
 QA_PORT=$((3000 + ISSUE_NUMBER % 100))
 QA_BASE="http://localhost:$QA_PORT"
 QA_LOG="/tmp/headball-dev-$ISSUE_NUMBER.log"
 
-# Rewrite any localhost:<port> in copied .env* files to this agent's port
+# Pick the app to QA. Default to headball; override per issue if the change
+# is Insider-only or cross-app. For cross-app issues, run QA against each
+# affected app serially (re-enter this block with a different QA_APP).
+QA_APP="${QA_APP:-headball}"
+QA_APP_DIR="$WORKTREE_PATH/apps/$QA_APP"
+[ -d "$QA_APP_DIR" ] || { echo "QA_APP=$QA_APP not found at $QA_APP_DIR"; exit 1; }
+
+# Rewrite any localhost:<port> in the app's .env* files to this agent's port.
+# Next.js loads .env.local from the app dir, not the workspace root.
 URL_OVERRIDES=""
-for f in "$WORKTREE_PATH/.env" "$WORKTREE_PATH/.env.local" "$WORKTREE_PATH/.env.development"; do
+for f in "$QA_APP_DIR/.env" "$QA_APP_DIR/.env.local" "$QA_APP_DIR/.env.development"; do
   [ -f "$f" ] && while IFS= read -r l; do
     URL_OVERRIDES="$URL_OVERRIDES ${l%%=*}=$(printf '%s' "${l#*=}" | sed -E "s|http(s?)://localhost:[0-9]+|http\\1://localhost:$QA_PORT|")"
   done < <(grep -E '^[A-Z_][A-Z0-9_]*=https?://localhost:[0-9]+' "$f" 2>/dev/null)
 done
 
-cd "$WORKTREE_PATH" && nohup env PORT=$QA_PORT $URL_OVERRIDES bun run dev > "$QA_LOG" 2>&1 &
+# Run the app's dev script directly so the turbo filter doesn't get in the way.
+cd "$QA_APP_DIR" && nohup env PORT=$QA_PORT $URL_OVERRIDES bun run dev > "$QA_LOG" 2>&1 &
 DEV_PID=$!
 for i in $(seq 1 45); do
   grep -qE "Ready in|Local:[[:space:]]+http|started server on" "$QA_LOG" && break

--- a/.claude/skills/pm/skill.md
+++ b/.claude/skills/pm/skill.md
@@ -24,10 +24,17 @@ You do NOT touch code, create worktrees, run builds, or do QA.
 Those are entirely the developer agent's responsibility.
 You only care about requirements and delivery status.
 
-**Project context:** Single Next.js 16 + Supabase repo. Worktrees live at
-`<repo-root>/.worktrees/<slug>/`. Branches are cut from `main`. Build/test
-commands run via Bun (`bun run lint`, `bunx tsc --noEmit`, `bun run build`,
-`bunx vitest run`, `bunx playwright test`). Browser QA uses the gstack
+**Project context:** Bun + Turborepo monorepo. Apps live at `apps/<game>/`
+(currently `apps/headball/`, `apps/insider/`, with `apps/hub/` planned).
+Shared code lives in `packages/<name>/` (`core`, `ui`, `types`, `content`).
+Supabase config and migrations live at the workspace root (`supabase/`,
+shared across all games). Worktrees live at `<repo-root>/.worktrees/<slug>/`.
+Branches are cut from `main`. Build/test commands run via Bun + Turbo at
+workspace root (`bun run lint`, `bun run build`, `bunx vitest run`). There
+is **no workspace-root `tsconfig.json`** — typecheck is per-package
+(`cd apps/<game> && bunx tsc --noEmit`). Playwright E2E is per-app
+(`cd apps/<game> && bunx playwright test`, serial `workers: 1`). Browser
+QA uses the gstack
 `/browse` skill. PRs are opened via the gstack `/ship` skill. UI work must
 follow `docs/DESIGN.md` (Stadium Energy aesthetic).
 
@@ -111,11 +118,12 @@ else
   echo "[FAIL] bun not found — install from https://bun.sh"
 fi
 
-# 6. Repo sanity — must be the Headball repo (app/ + docs/ + next.config.ts + package.json)
-if [ -d "app" ] && [ -d "docs" ] && [ -f "next.config.ts" ] && [ -f "package.json" ]; then
-  echo "[PASS] Running from Headball repo root ($(pwd))"
+# 6. Repo sanity — must be the Headball monorepo root
+#    (apps/, docs/, tsconfig.base.json, package.json)
+if [ -d "apps" ] && [ -d "docs" ] && [ -f "tsconfig.base.json" ] && [ -f "package.json" ]; then
+  echo "[PASS] Running from Headball monorepo root ($(pwd))"
 else
-  echo "[FAIL] Not at Headball repo root — cd to the repo and retry (need app/, docs/, next.config.ts, package.json)"
+  echo "[FAIL] Not at Headball monorepo root — cd to the repo and retry (need apps/, docs/, tsconfig.base.json, package.json)"
 fi
 
 # 7. main branch exists
@@ -185,8 +193,8 @@ Arguments:
 **Step 1: Preflight**
 
 ```bash
-test -d "$(pwd)/app" && test -d "$(pwd)/docs" && test -f "$(pwd)/next.config.ts" \
-  || { echo "ERROR: not at Headball repo root."; exit 1; }
+test -d "$(pwd)/apps" && test -d "$(pwd)/docs" && test -f "$(pwd)/tsconfig.base.json" \
+  || { echo "ERROR: not at Headball monorepo root."; exit 1; }
 which gh >/dev/null || { echo "ERROR: gh CLI not found."; exit 1; }
 
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)
@@ -448,9 +456,9 @@ echo "or to the dispatch bootstrap in .claude/skills/pm/skill.md."
 ```bash
 REPO_PATH="$(pwd)"
 
-# Must be Headball repo root
-test -d "$REPO_PATH/app" && test -d "$REPO_PATH/docs" && test -f "$REPO_PATH/next.config.ts" && test -f "$REPO_PATH/package.json" \
-  || { echo "ERROR: not at Headball repo root. cd to the repo first."; exit 1; }
+# Must be Headball monorepo root (apps/, docs/, tsconfig.base.json, package.json)
+test -d "$REPO_PATH/apps" && test -d "$REPO_PATH/docs" && test -f "$REPO_PATH/tsconfig.base.json" && test -f "$REPO_PATH/package.json" \
+  || { echo "ERROR: not at Headball monorepo root. cd to the repo first."; exit 1; }
 
 # Must not be inside a worktree
 case "$REPO_PATH" in

--- a/apps/headball/app/room/[code]/page.tsx
+++ b/apps/headball/app/room/[code]/page.tsx
@@ -7,6 +7,7 @@ import { supabase } from "@/lib/supabase"
 import { readPlayerId, useGameStore } from "@/lib/game-store"
 import type { Player, Room } from "@/lib/types"
 import { ConnectionStatus } from "@/components/connection-status"
+import { RoomJoinPrompt } from "@/components/room-join-prompt"
 import { Lobby } from "./lobby"
 import { Playing } from "./playing"
 import { Results } from "./results"
@@ -20,6 +21,7 @@ export default function RoomPage({
   const code = rawCode.toUpperCase()
 
   const room = useGameStore((s) => s.room)
+  const me = useGameStore((s) => s.me)
   const setRoom = useGameStore((s) => s.setRoom)
   const setPlayers = useGameStore((s) => s.setPlayers)
   const setMe = useGameStore((s) => s.setMe)
@@ -27,6 +29,7 @@ export default function RoomPage({
   const reset = useGameStore((s) => s.reset)
 
   const [loadError, setLoadError] = useState<string | null>(null)
+  const [bootstrapped, setBootstrapped] = useState(false)
   const [roomId, setRoomId] = useState<string | null>(null)
 
   useEffect(() => {
@@ -44,6 +47,7 @@ export default function RoomPage({
       if (roomErr || !roomRow) {
         setLoadError("ห้องไม่พบ")
         setConnectionStatus("DISCONNECTED")
+        setBootstrapped(true)
         return
       }
 
@@ -65,6 +69,7 @@ export default function RoomPage({
         ? (ps.find((p) => p.player_id === localPlayerId) ?? null)
         : null
       setMe(myRow)
+      setBootstrapped(true)
     }
 
     load()
@@ -127,10 +132,20 @@ export default function RoomPage({
           .eq("room_id", roomId)
           .order("join_order", { ascending: true })
         if (!refreshed) return
-        setPlayers(refreshed as Player[])
+        const ps = refreshed as Player[]
+        setPlayers(ps)
+        // If we're a returning member who isn't yet pinned in `me`, try to
+        // resolve from the freshly-refreshed roster.
+        if (!useGameStore.getState().me) {
+          const localPlayerId = readPlayerId()
+          const myRow = localPlayerId
+            ? (ps.find((p) => p.player_id === localPlayerId) ?? null)
+            : null
+          if (myRow) setMe(myRow)
+        }
       }
     },
-    [roomId, setRoom, setPlayers],
+    [roomId, setRoom, setPlayers, setMe],
   )
 
   useRoomRealtime({
@@ -161,13 +176,43 @@ export default function RoomPage({
     )
   }
 
-  if (!room) {
+  if (!bootstrapped || !room) {
     return (
       <>
         <ConnectionStatus />
         <main className="relative mx-auto flex min-h-[100dvh] w-full max-w-[480px] flex-col items-center justify-center gap-3 px-6 text-center">
           <p className="text-sm text-on-dark-soft">กำลังโหลด...</p>
         </main>
+      </>
+    )
+  }
+
+  // Direct-link visitor who hasn't joined this room yet.
+  if (!me) {
+    if (room.status === "PLAYING" || room.status === "ENDED") {
+      const message =
+        room.status === "PLAYING" ? "เกมเริ่มไปแล้ว" : "เกมจบไปแล้ว"
+      return (
+        <main className="relative mx-auto flex min-h-[100dvh] w-full max-w-[480px] flex-col items-center justify-center gap-6 px-6 text-center">
+          <h1 className="font-display text-[40px] uppercase tracking-[0.5px] text-on-dark">
+            {message}
+          </h1>
+          <p className="text-sm text-on-dark-soft">
+            เข้าร่วมเกมไม่ได้ ลองเริ่มห้องใหม่
+          </p>
+          <Link
+            href="/"
+            className="flex min-h-11 items-center justify-center rounded-xl border border-hairline bg-surface-elevated px-6 text-[15px] font-semibold tracking-[0.3px] text-on-dark transition-colors active:bg-surface"
+          >
+            กลับหน้าหลัก
+          </Link>
+        </main>
+      )
+    }
+    return (
+      <>
+        <ConnectionStatus />
+        <RoomJoinPrompt code={code} onJoined={() => void refetchAll()} />
       </>
     )
   }

--- a/apps/headball/components/room-join-prompt.tsx
+++ b/apps/headball/components/room-join-prompt.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import { useEffect, useRef, useState, useTransition } from "react"
+import { joinRoomAction } from "@/app/actions/join-room"
+import { displayNameSchema } from "@/lib/schemas"
+import { getOrCreatePlayerId } from "@/lib/game-store"
+
+const DISPLAY_NAME_MAX = 20
+
+export function RoomJoinPrompt({
+  code,
+  onJoined,
+}: {
+  code: string
+  onJoined: (playerId: string) => void
+}) {
+  const [name, setName] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+  const nameInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    queueMicrotask(() => nameInputRef.current?.focus())
+  }, [])
+
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (isPending) return
+
+    const parsed = displayNameSchema.safeParse(name)
+    if (!parsed.success) {
+      setError(parsed.error.issues[0]?.message ?? "ชื่อไม่ถูกต้อง")
+      nameInputRef.current?.focus()
+      return
+    }
+    setError(null)
+
+    let playerId: string
+    try {
+      playerId = getOrCreatePlayerId()
+    } catch {
+      setError("เปิดเบราว์เซอร์อีกครั้งแล้วลองใหม่")
+      return
+    }
+
+    startTransition(async () => {
+      const result = await joinRoomAction({
+        code,
+        displayName: parsed.data,
+        playerId,
+      })
+      if (!result.ok) {
+        setError(result.error)
+        return
+      }
+      onJoined(result.playerId)
+    })
+  }
+
+  return (
+    <main className="relative mx-auto flex min-h-[100dvh] w-full max-w-[480px] flex-col gap-8 px-6 pt-10 pb-10">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 h-56 bg-gradient-to-b from-goal/20 via-goal/5 to-transparent"
+      />
+
+      <header className="relative flex flex-col gap-3 text-center">
+        <p className="text-xs font-medium uppercase tracking-[0.3px] text-on-dark-muted">
+          เข้าห้อง / JOIN ROOM
+        </p>
+        <h1 className="font-hero text-[44px] leading-none tracking-[8px] text-on-dark tabular-nums">
+          {code}
+        </h1>
+      </header>
+
+      <form
+        onSubmit={onSubmit}
+        className="relative flex w-full flex-col gap-5"
+        noValidate
+      >
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="room-join-name"
+            className="text-xs font-medium uppercase tracking-[0.3px] text-on-dark-muted"
+          >
+            ชื่อของคุณ
+          </label>
+          <input
+            id="room-join-name"
+            ref={nameInputRef}
+            data-testid="room-join-name-input"
+            type="text"
+            inputMode="text"
+            autoComplete="off"
+            maxLength={DISPLAY_NAME_MAX}
+            placeholder="ชื่อเล่น"
+            value={name}
+            onChange={(event) => {
+              setName(event.target.value)
+              if (error) setError(null)
+            }}
+            aria-invalid={error ? true : undefined}
+            aria-describedby={error ? "room-join-name-error" : undefined}
+            disabled={isPending}
+            className="min-h-12 w-full rounded-lg border border-hairline bg-surface-elevated px-4 text-[16px] text-on-dark placeholder:text-on-dark-muted focus:border-goal focus:outline-none disabled:opacity-60"
+          />
+          <div className="flex items-center justify-between text-xs text-on-dark-muted">
+            <span>
+              {error ? (
+                <span
+                  id="room-join-name-error"
+                  role="alert"
+                  className="text-error"
+                >
+                  {error}
+                </span>
+              ) : (
+                "1–20 ตัวอักษร"
+              )}
+            </span>
+            <span className="tabular-nums">
+              {name.length}/{DISPLAY_NAME_MAX}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2 pt-4">
+          <button
+            type="submit"
+            disabled={isPending}
+            data-testid="room-join-cta"
+            className="flex min-h-14 w-full items-center justify-center rounded-xl bg-goal px-6 text-[17px] font-semibold tracking-[0.3px] text-on-dark transition-colors active:bg-goal-active disabled:bg-goal-disabled disabled:text-on-dark/70"
+          >
+            {isPending ? "กำลังเข้าห้อง..." : "เข้าห้อง"}
+          </button>
+        </div>
+      </form>
+    </main>
+  )
+}

--- a/docs/ISSUE-TRACKER.md
+++ b/docs/ISSUE-TRACKER.md
@@ -8,8 +8,9 @@
 | #7    | Rematch: settings not persisted + game-2 scoreboard stall      | :green_circle: | fix/7-rematch-settings-and-game2-stall | https://github.com/adisak1618/footballer-guesser/pull/10 | 4350638674 | merged |
 | #8    | GuessResult: non-top-N correct mislabeled as ทายผิด            | :green_circle: | fix/8-guess-result-correct-zero-pts | https://github.com/adisak1618/footballer-guesser/pull/9 | 4350638829 | merged |
 | #17   | Insider: multi-round scoring system (5-round match)            | :green_circle: | feat/17-insider-multi-round-scoring | https://github.com/adisak1618/footballer-guesser/pull/22 | 4413279081 | merged |
-| #23   | Insider: show round counter X/Y during play                    | :yellow_circle: |        |    | 4414990529 | workspace:18 / surface:24 — session 1778406803 |
-| #24   | Insider: between-rounds + game-end UX                          | :red_circle: |        |    | 4414990561 | deferred — dispatch after #23 merges (depends on #23 plumbing; DB-mutating) |
+| #23   | Insider: show round counter X/Y during play                    | :green_circle: | feat/23-round-counter-during-play | https://github.com/adisak1618/footballer-guesser/pull/25 | 4414990529 | merged |
+| #24   | Insider: between-rounds + game-end UX                          | :green_circle: | feat/24-insider-between-rounds-game-end-ux | https://github.com/adisak1618/footballer-guesser/pull/26 | 4414990561 | merged (migrations 0036/0037, 26 new tests) |
+| #27   | feat(platform): unified RoomSetupPanel + Category terminology  | :green_circle: | feat/27-unified-room-setup-panel-category | https://github.com/adisak1618/footballer-guesser/pull/28 | 4418725383 | merged (migration 0038 rounds_locked + change_insider_max_rounds RPC, packages/ui RoomSetupPanel, both apps migrated, /new deleted, Pack→Category UI rename) |
 
 Status legend:
 - :red_circle: Not started


### PR DESCRIPTION
## Summary
Gate `/room/<CODE>` direct-link visits behind an Insider-style name prompt for non-members, while letting returning members drop straight into the room. `PLAYING`/`ENDED` rooms reject direct-link joins with a Thai error + home link. Fixes the bug where sharing a Headball room URL silently let the recipient view someone else's lobby without joining as a player.

Fixes #29

## Changes
- `apps/headball/components/room-join-prompt.tsx` (new) — Insider-pattern name-prompt screen: room code shown locked in the header (no editable code input), single name input with Zod `displayNameSchema` validation, goal-colored CTA driven by `useTransition` pending state. Uses the existing `joinRoomAction` + `getOrCreatePlayerId` flow so the join action is unchanged.
- `apps/headball/app/room/[code]/page.tsx` — added a `bootstrapped` flag so we don't flash the prompt while the initial fetch is in flight; added gating between `room` load and `Lobby/Playing/Results` render: missing `me` + status `PLAYING`/`ENDED` → Thai block screen ("เกมเริ่มไปแล้ว" / "เกมจบไปแล้ว") with home link; missing `me` + status `LOBBY` → render `RoomJoinPrompt`. After successful join, `refetchAll()` repopulates players + me so the realtime channel doesn't need to race. The realtime `players` handler also re-derives `me` from localStorage on each refresh so the lobby resolves immediately after the join INSERT.

## Rubric verification
- [x] Non-member visiting `/room/<CODE>` directly sees an Insider-style join form — verified: cleared localStorage, navigated to `/room/XMMJHQ`, snapshot shows only `[textbox] "ชื่อของคุณ"` + `[button] "เข้าห้อง"`. Room code "XMMJHQ" rendered as `<h1>` header (`hasCodeInput: false`), submit class includes `bg-goal`, `bg-goal-active`, `bg-goal-disabled`.
- [x] Submitting joins the room, stores `playerId` in localStorage, drops into Lobby — verified: filled "Guest-QA29", clicked submit, navigated to lobby showing `Players (2/8)` with "Host-QA29" and "Guest-QA29(คุณ)"; `localStorage.headball_player_id = fee638a0-485e-485f-a06c-4259c50ce2ed`.
- [x] Returning player skips prompt and lands straight in Lobby/Playing/Results, refresh-safe — verified: after join, full reload to `/room/XMMJHQ` with same localStorage shows lobby immediately with no name-prompt flash; same `playerId` retained.
- [x] PLAYING blocks direct-link with Thai error + home link — verified: flipped `rooms.status` to `PLAYING` via service-role REST, cleared localStorage, visited `/room/XMMJHQ`; `<h1>` = "เกมเริ่มไปแล้ว", body "เข้าร่วมเกมไม่ได้ ลองเริ่มห้องใหม่", `[link] "กลับหน้าหลัก"`.
- [x] ENDED blocks direct-link with Thai error + home link — verified: flipped `rooms.status` to `ENDED`, cleared localStorage, visited `/room/XMMJHQ`; `<h1>` = "เกมจบไปแล้ว", same supporting copy + home link.
- [x] Room-code field is read-only/locked when arriving from a direct URL — verified: DOM has no `<input>` for code (only `#room-join-name`); code is a static `<h1 class="font-hero text-[44px] tracking-[8px]">XMMJHQ</h1>`, mirroring Insider's lobby JoinView pattern.
- [x] Flow matches Insider behavior referenced in `apps/insider/app/join/join-insider-room-form.tsx` — verified: same Zod `displayNameSchema`, same `getOrCreatePlayerId` → `joinRoomAction({ code, displayName, playerId })` shape, same `bg-goal` CTA + `min-h-12` input styling. Header copy "เข้าห้อง / JOIN ROOM" + tracked code in `font-hero` mirrors Insider lobby `JoinView`.

States verified:
- [x] Happy path — non-member sees name prompt → submits → lands in Lobby (covered above).
- [x] Loading state — submit button renders `isPending ? "กำลังเข้าห้อง..." : "เข้าห้อง"` with `disabled={isPending}` (room-join-prompt.tsx:104, 130, 134) via `useTransition`.
- [x] Empty state — returning member skips form entirely (refresh test above); `bootstrapped` flag prevents flash while initial fetch is in flight.
- [x] Error state — PLAYING/ENDED blocks verified above; empty-name submit shows inline "ใส่ชื่อก่อนนะ" beside the name field.

Visual comparison: name-prompt screenshot at `/tmp/headball-room-join-prompt.png` confirms Stadium Energy aesthetic — dark navy bg, "เข้าห้อง / JOIN ROOM" subtitle, tracked `font-hero` room code, single name input, goal-colored CTA. Mirrors `apps/insider/app/room/[code]/lobby.tsx` JoinView (the Insider direct-link join view is the same pattern as `/join`).

Groomed rubric: https://github.com/adisak1618/footballer-guesser/issues/29#issuecomment-4423434304

Generated with [Claude Code](https://claude.com/claude-code)
