### PR TITLE
fix(warewolf): desktop-friendly responsive layout (4 issues)

### DIFF
--- a/apps/warewolf/app/[lang]/landing.module.css
+++ b/apps/warewolf/app/[lang]/landing.module.css
@@ -339,18 +339,117 @@
 }
 
 @media (min-width: 720px) {
-  /* Desktop breathing room per Open Question #4 in story Tech Notes. */
-  .page {
-    max-width: 560px;
-    margin: 0 auto;
-    box-shadow: 0 0 0 1px rgba(26, 22, 18, 0.08);
-  }
-
+  /* Tablet: keep mobile-flow but scale the headline + cards. */
   .title {
-    font-size: 52px;
+    font-size: 64px;
   }
 
   .cardFanCard {
-    width: 96px;
+    width: 104px;
+  }
+
+  .ctaRow {
+    flex-direction: row;
+    justify-content: center;
+    gap: 14px;
+  }
+
+  .cta {
+    min-width: 220px;
+  }
+}
+
+@media (min-width: 1024px) {
+  /*
+   * Desktop hero. Mobile-first stays default; on wide viewports the page
+   * uses the full width with breathing room via inner content max-width.
+   * Replaces the previous max-width:560px cap that locked desktop to a
+   * narrow mobile-shaped column (ISSUE-001).
+   */
+  .topbar {
+    max-width: 1100px;
+    width: 100%;
+    margin-inline: auto;
+    padding: 20px 28px;
+  }
+
+  .hero {
+    border: none;
+    background: var(--color-cream);
+    background-image: radial-gradient(rgba(120, 90, 40, 0.05) 1px, transparent 1px);
+    background-size: 3px 3px;
+    border-top: 1px solid var(--color-ink);
+    border-bottom: 1px solid var(--color-ink);
+    padding-block: 32px 16px;
+  }
+
+  .heroHead {
+    max-width: 880px;
+    margin-inline: auto;
+    padding: 24px 28px 12px;
+  }
+
+  .title {
+    font-size: clamp(72px, 9vw, 132px);
+    line-height: 0.95;
+  }
+
+  .titleSub,
+  .titleSubTh {
+    font-size: 22px;
+    margin-top: 14px;
+  }
+
+  .divider {
+    max-width: 720px;
+    margin-inline: auto;
+    padding: 20px 28px 0;
+    font-size: 16px;
+  }
+
+  .heroCards {
+    padding: 36px 0 24px;
+    min-height: 320px;
+  }
+
+  .cardFanCard {
+    width: 140px;
+    box-shadow:
+      0 14px 28px rgba(26, 22, 18, 0.28),
+      inset 0 0 0 1px rgba(245, 236, 214, 0.4);
+  }
+
+  .cardFanCard:nth-child(1) {
+    transform: translateX(110px) rotate(-26deg);
+  }
+
+  .cardFanCard:nth-child(2) {
+    transform: translateX(55px) rotate(-13deg);
+    z-index: 2;
+  }
+
+  .cardFanCard:nth-child(3) {
+    transform: translateY(-22px);
+    z-index: 3;
+  }
+
+  .cardFanCard:nth-child(4) {
+    transform: translateX(-55px) rotate(13deg);
+    z-index: 2;
+  }
+
+  .cardFanCard:nth-child(5) {
+    transform: translateX(-110px) rotate(26deg);
+  }
+
+  .below {
+    max-width: 760px;
+    margin-inline: auto;
+    padding: 28px 28px 40px;
+  }
+
+  .pitch,
+  .pitchTh {
+    font-size: 17px;
   }
 }

--- a/apps/warewolf/app/[lang]/rules/page.tsx
+++ b/apps/warewolf/app/[lang]/rules/page.tsx
@@ -25,6 +25,7 @@ import { useEffect, useMemo, useRef, useState } from "react"
 import { useLocale, useTranslations } from "next-intl"
 
 import { CardArt } from "@/components/CardArt"
+import { Container } from "@/components/Container"
 import { ROLES, ROLE_IDS, type RoleId, type Team } from "@social-hub/content"
 import { RULES_CHAPTERS, type RulesBlock } from "@/lib/rules-content"
 
@@ -128,13 +129,17 @@ export default function RulesPage() {
           position: "sticky",
           top: 0,
           zIndex: 10,
+          borderBottom: "var(--b)",
+          background: "var(--color-parchment)",
+        }}
+      >
+      <Container
+        style={{
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
           gap: "var(--s-2)",
           padding: "var(--s-2) var(--s-4)",
-          borderBottom: "var(--b)",
-          background: "var(--color-parchment)",
         }}
       >
         <Link
@@ -195,14 +200,16 @@ export default function RulesPage() {
         >
           {langLabel}
         </Link>
+      </Container>
       </header>
 
       {/* Page title */}
-      <section
+      <section style={{ flexShrink: 0 }}>
+      <Container
+        variant="narrow"
         style={{
           textAlign: "center",
           padding: "var(--s-4) var(--s-4) var(--s-2)",
-          flexShrink: 0,
         }}
       >
         <div
@@ -229,14 +236,19 @@ export default function RulesPage() {
         >
           {t("title")}
         </h1>
+      </Container>
       </section>
 
       {/* Collapsible TOC */}
+      <Container
+        variant="narrow"
+        style={{ paddingInline: "var(--s-4)" }}
+      >
       <nav
         data-testid="rules-toc"
         data-open={tocOpen ? "true" : "false"}
         style={{
-          margin: "var(--s-2) var(--s-4)",
+          margin: "var(--s-2) 0",
           border: "var(--b)",
           background: "var(--color-cream)",
           fontStyle: "italic",
@@ -318,11 +330,12 @@ export default function RulesPage() {
           </ol>
         ) : null}
       </nav>
+      </Container>
 
       {/* Body — chapters I-VI then chapter VII compendium */}
+      <Container variant="narrow" style={{ flex: 1 }}>
       <article
         style={{
-          flex: 1,
           padding: "var(--s-3) var(--s-4) var(--s-6)",
         }}
       >
@@ -363,6 +376,7 @@ export default function RulesPage() {
           <RoleCompendium lang={lang} />
         </section>
       </article>
+      </Container>
 
       {/* Sticky bottom CTA */}
       <div
@@ -371,11 +385,15 @@ export default function RulesPage() {
           position: "sticky",
           bottom: 0,
           flexShrink: 0,
+          borderTop: "var(--b)",
+          background: "var(--color-parchment)",
+        }}
+      >
+      <Container
+        style={{
           display: "flex",
           gap: "var(--s-2)",
           padding: "var(--s-2) var(--s-4)",
-          borderTop: "var(--b)",
-          background: "var(--color-parchment)",
         }}
       >
         <Link
@@ -416,6 +434,7 @@ export default function RulesPage() {
         >
           {t("backToSetup")}
         </Link>
+      </Container>
       </div>
     </main>
   )

--- a/apps/warewolf/app/[lang]/setup/customize/page.tsx
+++ b/apps/warewolf/app/[lang]/setup/customize/page.tsx
@@ -35,6 +35,7 @@ import type { CSSProperties } from "react"
 import { AddRoleSheet } from "@/components/AddRoleSheet"
 import { BalanceScale } from "@/components/BalanceScale"
 import { CardArt } from "@/components/CardArt"
+import { Container } from "@/components/Container"
 import { PlayableBanner, type PlayableBannerState } from "@/components/PlayableBanner"
 import { RoleDetailModal } from "@/components/RoleDetailModal"
 import { decodeSetup, encodeSetup } from "@/lib/share-url"
@@ -239,12 +240,16 @@ function CustomizePageInner() {
     >
       <header
         style={{
+          borderBottom: "var(--b)",
+          background: "var(--color-parchment)",
+        }}
+      >
+      <Container
+        style={{
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
           padding: "var(--s-3) var(--s-4)",
-          borderBottom: "var(--b)",
-          background: "var(--color-parchment)",
         }}
       >
         <Link
@@ -286,24 +291,29 @@ function CustomizePageInner() {
         >
           {otherLangLabel}
         </Link>
+      </Container>
       </header>
 
       {importedInvalid ? (
         <div
-          data-testid="customize-imported-invalid"
-          role="status"
           style={{
-            padding: "10px 14px",
             background: "var(--color-blood-bg)",
-            color: "#5a1818",
             borderBottom: "2px solid var(--color-blood)",
-            fontStyle: "italic",
-            fontWeight: 500,
-            fontSize: 13,
-            textAlign: "center",
           }}
         >
-          {t("importedInvalid")}
+          <Container
+            testId="customize-imported-invalid"
+            style={{
+              padding: "10px 14px",
+              color: "#5a1818",
+              fontStyle: "italic",
+              fontWeight: 500,
+              fontSize: 13,
+              textAlign: "center",
+            }}
+          >
+            {t("importedInvalid")}
+          </Container>
         </div>
       ) : null}
 
@@ -320,15 +330,17 @@ function CustomizePageInner() {
           borderBottom: "var(--b)",
         }}
       >
-        <BalanceScale
-          wolfSum={result.wolfSum}
-          villageSum={result.villageSum}
-          balance={result.balance}
-          hasBlocker={!result.ok}
-        />
-        <div style={{ padding: "0 var(--s-4) var(--s-3)" }}>
-          <PlayableBanner state={bannerState} reason={reasonText} />
-        </div>
+        <Container>
+          <BalanceScale
+            wolfSum={result.wolfSum}
+            villageSum={result.villageSum}
+            balance={result.balance}
+            hasBlocker={!result.ok}
+          />
+          <div style={{ padding: "0 var(--s-4) var(--s-3)" }}>
+            <PlayableBanner state={bannerState} reason={reasonText} />
+          </div>
+        </Container>
       </div>
 
       {/* Body: card grid (LEFT on desktop ≥1024px, full-width on mobile) +
@@ -478,12 +490,16 @@ function CustomizePageInner() {
           left: 0,
           right: 0,
           bottom: 0,
-          padding: "8px 14px",
           borderTop: "var(--b)",
           background: "var(--color-cream)",
+          zIndex: 3,
+        }}
+      >
+      <Container
+        style={{
+          padding: "8px 14px",
           display: "flex",
           gap: 6,
-          zIndex: 3,
         }}
       >
         <button
@@ -510,6 +526,7 @@ function CustomizePageInner() {
         >
           {t("saveSetup")}
         </button>
+      </Container>
       </footer>
 
       {/* Mobile overlay: RoleDetailModal */}

--- a/apps/warewolf/app/[lang]/setup/customize/page.tsx
+++ b/apps/warewolf/app/[lang]/setup/customize/page.tsx
@@ -345,10 +345,9 @@ function CustomizePageInner() {
 
       {/* Body: card grid (LEFT on desktop ≥1024px, full-width on mobile) +
           detail panel (RIGHT on desktop, overlay on mobile).
-          Grid-template-columns lives in the <style> block below so the media
-          query can switch it; inline style cannot host media queries. */}
-      <div
-        data-testid="customize-body"
+          Grid-template-columns lives in globals.css `.customize-body` so the
+          media query can switch it; inline style cannot host media queries. */}
+      <Container
         className="customize-body"
         style={{
           flex: 1,
@@ -356,6 +355,7 @@ function CustomizePageInner() {
           display: "grid",
           gap: "var(--s-4)",
         }}
+        testId="customize-body"
       >
         {/* Card grid column */}
         <section
@@ -480,7 +480,7 @@ function CustomizePageInner() {
             </div>
           )}
         </aside>
-      </div>
+      </Container>
 
       {/* Sticky bottom Save CTA */}
       <footer
@@ -614,25 +614,6 @@ function CustomizePageInner() {
         </div>
       ) : null}
 
-      {/* Desktop 2-column layout per Pass 6. Inline <style> here so we can keep
-          the page self-contained; tokens come from globals.css. The same
-          breakpoint hides the mobile overlay so the right-column panel is
-          the single source of detail render. */}
-      <style>{`
-        .customize-body { grid-template-columns: 1fr; }
-        @media (min-width: 1024px) {
-          .customize-body {
-            grid-template-columns: 1fr minmax(320px, 420px);
-            max-width: 1100px;
-            margin: 0 auto;
-            width: 100%;
-          }
-          .customize-detail-overlay { display: none !important; }
-        }
-        @media (max-width: 1023px) {
-          .customize-detail-panel { display: none; }
-        }
-      `}</style>
     </main>
   )
 }

--- a/apps/warewolf/app/[lang]/setup/page.tsx
+++ b/apps/warewolf/app/[lang]/setup/page.tsx
@@ -20,6 +20,7 @@ import { Suspense, useEffect, useMemo, useRef, useState } from "react"
 import { useLocale, useTranslations } from "next-intl"
 
 import { ArchetypeChipStrip } from "@/components/ArchetypeChipStrip"
+import { Container } from "@/components/Container"
 import { SetupCard } from "@/components/SetupCard"
 import { SolverErrorRow } from "@/components/SolverErrorRow"
 import { computeSetupList, isSolverError, type Setup } from "@/lib/solver"
@@ -129,16 +130,20 @@ function SetupListPageInner() {
     >
       <header
         style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          gap: "var(--s-3)",
-          padding: "var(--s-3) var(--s-4)",
           borderBottom: "var(--b)",
           background: "var(--color-cream)",
           flexShrink: 0,
         }}
       >
+        <Container
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: "var(--s-3)",
+            padding: "var(--s-3) var(--s-4)",
+          }}
+        >
         <Link
           href={`/${lang}`}
           data-testid="setup-back-home"
@@ -197,15 +202,16 @@ function SetupListPageInner() {
         >
           {selectedLangLabel}
         </Link>
+        </Container>
       </header>
 
       <section
         style={{
-          padding: "var(--s-4) var(--s-4) var(--s-3)",
           borderBottom: "var(--b)",
           background: "var(--color-parchment)",
         }}
       >
+        <Container style={{ padding: "var(--s-4) var(--s-4) var(--s-3)" }}>
         <p
           data-testid="setup-subhead"
           style={{
@@ -307,28 +313,39 @@ function SetupListPageInner() {
             +
           </button>
         </div>
+        </Container>
       </section>
 
-      <ArchetypeChipStrip
-        playerCount={playerCount}
-        activeFilters={activeFilters}
-        onChange={(next) => {
-          // Diff and toggle each changed id; the store owns the set.
-          const current = activeFilters
-          for (const id of next) if (!current.has(id)) toggleArchetypeFilter(id)
-          for (const id of current) if (!next.has(id)) toggleArchetypeFilter(id)
+      <div
+        style={{
+          borderBottom: "var(--b)",
+          background: "var(--color-parchment)",
+          flexShrink: 0,
         }}
-        lang={lang}
-      />
+      >
+        <Container>
+          <ArchetypeChipStrip
+            playerCount={playerCount}
+            activeFilters={activeFilters}
+            onChange={(next) => {
+              // Diff and toggle each changed id; the store owns the set.
+              const current = activeFilters
+              for (const id of next) if (!current.has(id)) toggleArchetypeFilter(id)
+              for (const id of current) if (!next.has(id)) toggleArchetypeFilter(id)
+            }}
+            lang={lang}
+          />
+        </Container>
+      </div>
 
       <section
         data-testid="setup-list"
         style={{
           flex: 1,
-          padding: "var(--s-3) var(--s-4) var(--s-5)",
           overflowY: "auto",
         }}
       >
+        <Container style={{ padding: "var(--s-3) var(--s-4) var(--s-5)" }}>
         {setupList.length === 0 ? (
           <p
             data-testid="setup-list-empty"
@@ -366,6 +383,7 @@ function SetupListPageInner() {
             )
           })
         )}
+        </Container>
       </section>
 
       {toast !== null ? (

--- a/apps/warewolf/app/globals.css
+++ b/apps/warewolf/app/globals.css
@@ -150,3 +150,39 @@
     border: 0;
   }
 }
+
+/*
+ * Customize page 2-column layout (Pass 6).
+ *
+ * Mobile: single column, role detail opens as a bottom-sheet modal.
+ * Desktop (>=1024px): left card grid + right sticky detail panel.
+ * Both columns share the same selection state from useWarewolfStore.
+ *
+ * Hoisted from an inline <style> inside customize/page.tsx so the rules
+ * load reliably without any React-style hoisting timing concerns
+ * (ISSUE-004 — design doc Eng Review Decision Pass 6).
+ */
+.customize-body {
+  grid-template-columns: 1fr;
+}
+
+.customize-detail-panel {
+  display: none;
+}
+
+@media (min-width: 1024px) {
+  .customize-body {
+    grid-template-columns: 1fr minmax(320px, 420px);
+  }
+
+  .customize-detail-panel {
+    display: block;
+    position: sticky;
+    top: 200px;
+    align-self: start;
+  }
+
+  .customize-detail-overlay {
+    display: none !important;
+  }
+}

--- a/apps/warewolf/components/Container.test.tsx
+++ b/apps/warewolf/components/Container.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { Container } from "./Container"
+
+describe("<Container>", () => {
+  it("renders children", () => {
+    render(
+      <Container>
+        <span data-testid="child">hello</span>
+      </Container>,
+    )
+    expect(screen.getByTestId("child")).toBeInTheDocument()
+  })
+
+  it("applies default max-width of 1100px", () => {
+    const { container } = render(
+      <Container testId="container">
+        <span>x</span>
+      </Container>,
+    )
+    const el = container.firstElementChild as HTMLElement
+    expect(el.style.maxWidth).toBe("1100px")
+    expect(el.style.marginInline).toBe("auto")
+  })
+
+  it("applies narrow variant max-width for long-form text", () => {
+    const { container } = render(
+      <Container variant="narrow">
+        <span>x</span>
+      </Container>,
+    )
+    const el = container.firstElementChild as HTMLElement
+    expect(el.style.maxWidth).toBe("760px")
+  })
+
+  it("forwards className prop", () => {
+    const { container } = render(
+      <Container className="my-section">
+        <span>x</span>
+      </Container>,
+    )
+    const el = container.firstElementChild as HTMLElement
+    expect(el.className).toBe("my-section")
+  })
+
+  it("merges custom inline style with the layout base", () => {
+    const { container } = render(
+      <Container style={{ padding: "12px", color: "red" }}>
+        <span>x</span>
+      </Container>,
+    )
+    const el = container.firstElementChild as HTMLElement
+    // Base layout still applies.
+    expect(el.style.maxWidth).toBe("1100px")
+    expect(el.style.marginInline).toBe("auto")
+    // Caller overrides still apply.
+    expect(el.style.padding).toBe("12px")
+    expect(el.style.color).toBe("red")
+  })
+
+  it("forwards testId as data-testid", () => {
+    render(
+      <Container testId="my-container">
+        <span>x</span>
+      </Container>,
+    )
+    expect(screen.getByTestId("my-container")).toBeInTheDocument()
+  })
+})

--- a/apps/warewolf/components/Container.tsx
+++ b/apps/warewolf/components/Container.tsx
@@ -1,0 +1,58 @@
+/**
+ * <Container> — desktop-friendly max-width wrapper.
+ *
+ * Mobile-first: at viewport widths below the max, this is a no-op (the inner
+ * content stretches to the available width minus the page's existing padding).
+ * On wider viewports, the content centers in a 1100px column so reading
+ * lengths stay comfortable and cards don't balloon edge-to-edge.
+ *
+ * Designed to wrap section CONTENT, not section CHROME — so borders and
+ * sticky bars can still span full bleed. Place inside each top-level
+ * <header>, <section>, <footer> rather than around the whole <main>.
+ */
+import type { CSSProperties, ReactNode } from "react"
+
+interface ContainerProps {
+  children: ReactNode
+  /**
+   * Override the default 1100px max-width. Use `narrow` for long-form text
+   * (rules body) where ~80ch is the readable optimum.
+   */
+  variant?: "default" | "narrow"
+  /**
+   * Merge additional inline styles. Keeps the responsibility for layout
+   * concerns local to each call site rather than introducing new props.
+   */
+  style?: CSSProperties
+  className?: string
+  /** Optional data-testid passthrough for QA. */
+  testId?: string
+}
+
+const MAX_WIDTHS = {
+  default: 1100,
+  narrow: 760,
+} as const
+
+export function Container({
+  children,
+  variant = "default",
+  style,
+  className,
+  testId,
+}: ContainerProps) {
+  return (
+    <div
+      data-testid={testId}
+      className={className}
+      style={{
+        width: "100%",
+        maxWidth: MAX_WIDTHS[variant],
+        marginInline: "auto",
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Fixes 4 responsive layout bugs found by `/qa-only` after the Warewolf V1 ship. Mobile-first focus preserved everywhere; desktop now gets an intentional layout instead of either a narrow mobile column (landing) or edge-to-edge stretch (everywhere else).

## What changed

- **`<Container>` component** at `apps/warewolf/components/Container.tsx` with default (max-w 1100px) and narrow (760px) variants. Wraps setup list, rules, and customize page content. Borders stay full-bleed; only the content centers. (+ Container.test.tsx, 6 tests)
- **Customize 2-column desktop layout** per Pass 6 spec drift. At ≥1024px the role grid stays on the left, a sticky right-side detail panel (`position: sticky; top: 200px`) renders the selected role's card art, name, badges, mechanic, and Replace/Delete buttons. Modal stays as the mobile/tablet behavior. CSS hoisted from inline `<style>` to `globals.css` for reliable bundle inclusion.
- **Landing desktop rebuild.** Replaces the `max-width: 560px` cap on `.page` with a real tablet (≥720px) + desktop (≥1024px) treatment. Title scales `clamp(72px, 9vw, 132px)`, card-fan cards grow to 140px with wider rotations and deeper shadow, content centers in explicit per-section max-widths. Grimoire tokens unchanged.

## Issues fixed (from QA report)

| # | Severity | Issue | Fix |
|---|---|---|---|
| ISSUE-001 | Critical | Landing locked to ~480px narrow column on desktop | New responsive treatment per breakpoint |
| ISSUE-002 | High | Setup list edge-to-edge at 1280px | `<Container>` wrapper |
| ISSUE-003 | High | Rules body copy lines >150 chars on desktop | `<Container>` with narrow (760px) variant for article body |
| ISSUE-004 | High | Customize single-column at desktop (spec drift from Pass 6) | 2-column with sticky right-side detail panel at ≥1024px |

ISSUE-005 (setup mobile cramped) and ISSUE-006 (setup mobile first-paint empty) deferred — low severity, no observed regression with these fixes.

## Test plan

- [x] **Unit + component tests:** 22 files / 182 tests pass (`cd apps/warewolf && bun run test`). Container.test.tsx adds 6 new tests.
- [x] **Typecheck:** clean (`cd apps/warewolf && bunx tsc --noEmit`)
- [x] **Manual desktop pass at 1280×800:**
  - [x] Landing renders full-width with hero card-fan scaled up; title at correct clamp size
  - [x] Setup list rows centered in container (no edge-to-edge stretch); parchment margins visible
  - [x] Rules body copy at readable line length (~80 char); compendium cards centered
  - [x] Customize shows 2-column layout; right-side panel renders placeholder initially
  - [x] Customize: clicking a card populates the sticky right-side panel (Seer test passed) with card art, name, badges, mechanic, Replace + Delete buttons
- [x] **Manual mobile pass at 375×812:** all 4 pages render identical to pre-fix (no regression)
- [x] **Console:** 0 JS errors; only pre-existing LCP image perf warnings on customize and setup

## Files changed

- Created: `apps/warewolf/components/Container.tsx`, `apps/warewolf/components/Container.test.tsx`
- Modified: `apps/warewolf/app/[lang]/page.tsx` (landing rebuild via CSS), `apps/warewolf/app/[lang]/landing.module.css`, `apps/warewolf/app/[lang]/setup/page.tsx`, `apps/warewolf/app/[lang]/setup/customize/page.tsx`, `apps/warewolf/app/[lang]/rules/page.tsx`, `apps/warewolf/app/globals.css`

## Known gaps

- **Tablet (768×1024) not visually verified** in this pass. Tablet rules (≥720px) added; recommend a Playwright snapshot at that breakpoint before launch.
- **Customize `<aside data-testid="customize-detail-panel">` may flash an empty panel server-side during hydration** before CSS loads (noted by implementing agent). Hoisting CSS to globals.css helps but doesn't fully eliminate. Low priority; deferred.
- **Pre-existing:** `middleware` → `proxy` Next 16 deprecation warning unchanged.
- **Pre-existing:** `@supabase/postgrest-js` still leaking into bundle from `packages/core`. Worth investigating before launch for bundle-budget reasons (US-025 CI gate may or may not catch it).

## QA evidence

Before/after screenshots in `.gstack/qa-reports/screenshots/`. Full report at `.gstack/qa-reports/qa-report-warewolf-responsive-2026-05-13.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)